### PR TITLE
Fixed missing group colors if more than 8 groups defined

### DIFF
--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -388,7 +388,8 @@ export class GroupsController {
       color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
     }
     if (6 !== color.length) {
-      throw new Error(`Invalid color: ${color}`);
+      CommonController.showToastError(`Cannot generate color. Invalid value: ${color}`)
+      return "black";
     }
     const r = parseInt(color.slice(0, 2), 16);
     const g = parseInt(color.slice(2, 4), 16);

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -1,4 +1,4 @@
-import { CommonController } from "./controller-common.js"
+import { CommonController } from "./controller-common.js";
 import { GroupsService } from "./service-group.js";
 import { GroupsView } from "./view-group.js";
 
@@ -335,8 +335,8 @@ export class GroupsController {
    */
   #getAvailableColors() {
     const definedColors = ["navy", "aqua", "green", "orange", "red", "blue", "yellow", "plum"];
-    const pageHeadElement = document.getElementsByTagName('head')[0];
-    const generatedColors = Array.from(pageHeadElement.getElementsByTagName("style")).map(element => {
+    const pageHeadElement = document.getElementsByTagName("head")[0];
+    const generatedColors = Array.from(pageHeadElement.getElementsByTagName("style")).map((element) => {
       return element.innerHTML.match(".background-([0-9a-fA-F]+)")[1];
     });
     return definedColors.concat(generatedColors);
@@ -349,9 +349,9 @@ export class GroupsController {
    */
   #createColorClass(color) {
     const className = `background-${color}`;
-    const classElement = document.createElement('style');
+    const classElement = document.createElement("style");
     classElement.innerHTML = `.${className} { background: #${color}; color: ${this.#invertColor(color)}; }`;
-    document.getElementsByTagName('head')[0].appendChild(classElement);
+    document.getElementsByTagName("head")[0].appendChild(classElement);
     return className;
   }
 

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -59,15 +59,11 @@ export class GroupsController {
     this.#groupColumns.forEach((column) => {
       if ("update" === column.dataset.action) {
         // get color from array and then remove it so no duplicates are selected (in next iterations)
-        if (colors.length > 0) {
-          const selectedColor = this.#getRandom(colors, true);
-          column.classList.add("background-" + selectedColor);
-        } else {
-          const randomColor = Math.floor(Math.random()*0xFFFFFF).toString(16);
-          column.classList.add(this.#createColorClass(randomColor));
-        }
+        column.classList.add(colors.length > 0
+            ? "background-" + this.#getRandomElement(colors, true)
+            : this.#createColorClass(this.#getRandomColor()));
         // get animation from array (duplicates are allowed in this case)
-        column.classList.add(this.#getRandom(animations, false));
+        column.classList.add(this.#getRandomElement(animations, false));
       } else {
         // new group column should always appear from right and have gray background
         column.classList.add("background-violet");
@@ -365,7 +361,7 @@ export class GroupsController {
    * @param {Boolean} remove If we want to remove the received random element from array (to prevent duplicates)
    * @returns random element from input array
    */
-  #getRandom(array, remove) {
+  #getRandomElement(array, remove) {
     const randomItem = array[Math.floor(Math.random() * array.length)];
     if (remove) {
       var index = array.indexOf(randomItem);
@@ -374,5 +370,13 @@ export class GroupsController {
       }
     }
     return randomItem;
+  }
+
+  /**
+   * Method used to generate and receive random color
+   * @returns String with random color in form of a HEX number
+   */
+  #getRandomColor() {
+    return Math.floor(Math.random() * 0xffffff).toString(16);
   }
 }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -346,6 +346,14 @@ export class GroupsController {
     return definedColors.concat(generatedColors);
   }
 
+  #createColorClass(color) {
+    const className = `background-${color}`;
+    const classElement = document.createElement('style');
+    classElement.innerHTML = `.${className} { background: #${color}; color: black; }`;
+    document.getElementsByTagName('head')[0].appendChild(classElement);
+    return className;
+  }
+
   /**
    * Method used to receive random element from provided array
    * @param {Object} array The array from which we want to receive element

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -350,7 +350,7 @@ export class GroupsController {
   #createColorClass(color) {
     const className = `background-${color}`;
     const classElement = document.createElement("style");
-    classElement.innerHTML = `.${className} { background: #${color}; color: ${this.#invertColor(color)}; }`;
+    classElement.innerHTML = `.${className} { background: #${color}; color: ${this.#contrastColor(color)}; }`;
     document.getElementsByTagName("head")[0].appendChild(classElement);
     return className;
   }
@@ -380,7 +380,12 @@ export class GroupsController {
     return Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, "0");
   }
 
-  #invertColor(color) {
+  /**
+   * Method used to generate color with good contrast to the input (black or white)
+   * @param {String} color The color in HEX for which we want to generate good contrast color
+   * @returns black or white color in HEX which has the better contrast to the input color
+   */
+  #contrastColor(color) {
     if (0 === color.indexOf("#")) {
       color = color.slice(1);
     }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -377,7 +377,7 @@ export class GroupsController {
    * @returns String with random color in form of a HEX number
    */
   #getRandomColor() {
-    return Math.floor(Math.random() * 0xffffff).toString(16);
+    return Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, "0");
   }
 
   #invertColor(color) {

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -54,7 +54,7 @@ export class GroupsController {
    * Method used to set style for all group columns (position, colors and animation)
    */
   #initStyle() {
-    const colors = ["navy", "aqua", "green", "orange", "red", "blue", "yellow", "plum"];
+    const colors = this.#getAvailableColors();
     const animations = ["column-from-top", "column-from-right", "column-from-bottom", "column-from-left"];
     this.#groupColumns.forEach((column) => {
       if ("update" === column.dataset.action) {
@@ -335,6 +335,15 @@ export class GroupsController {
    */
   #clearDimension(column) {
     column.parentNode.removeAttribute("style");
+  }
+
+  #getAvailableColors() {
+    const definedColors = ["navy", "aqua", "green", "orange", "red", "blue", "yellow", "plum"];
+    const pageHeadElement = document.getElementsByTagName('head')[0];
+    const generatedColors = Array.from(pageHeadElement.getElementsByTagName("style")).map(element => {
+      return element.innerHTML.match(".background-([0-9a-fA-F]+)")[1];
+    });
+    return definedColors.concat(generatedColors);
   }
 
   /**

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -59,9 +59,17 @@ export class GroupsController {
     this.#groupColumns.forEach((column) => {
       if ("update" === column.dataset.action) {
         // get color from array and then remove it so no duplicates are selected (in next iterations)
-        const selectedColor = this.#getRandom(colors, true);
-        column.classList.add("background-" + selectedColor);
-        column.querySelector(".group-title").classList.add("background-" + selectedColor);
+        if (colors.length > 0) {
+          const selectedColor = this.#getRandom(colors, true);
+          column.classList.add("background-" + selectedColor);
+          column.querySelector(".group-title").classList.add("background-" + selectedColor);
+        } else {
+          const randomColorHex = Math.floor(Math.random()*16777215).toString(16);
+          const randomColorClass = document.createElement('style');
+          randomColorClass.innerHTML = `.background-${randomColorHex} { background: #${randomColorHex}; color: black; }`;
+          document.getElementsByTagName('head')[0].appendChild(randomColorClass);
+          column.classList.add("background-" + randomColorHex);
+        }
         // get animation from array (duplicates are allowed in this case)
         column.classList.add(this.#getRandom(animations, false));
       } else {

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -63,11 +63,8 @@ export class GroupsController {
           const selectedColor = this.#getRandom(colors, true);
           column.classList.add("background-" + selectedColor);
         } else {
-          const randomColorHex = Math.floor(Math.random()*0xFFFFFF).toString(16);
-          const randomColorClass = document.createElement('style');
-          randomColorClass.innerHTML = `.background-${randomColorHex} { background: #${randomColorHex}; color: black; }`;
-          document.getElementsByTagName('head')[0].appendChild(randomColorClass);
-          column.classList.add("background-" + randomColorHex);
+          const randomColor = Math.floor(Math.random()*0xFFFFFF).toString(16);
+          column.classList.add(this.#createColorClass(randomColor));
         }
         // get animation from array (duplicates are allowed in this case)
         column.classList.add(this.#getRandom(animations, false));

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -62,7 +62,6 @@ export class GroupsController {
         if (colors.length > 0) {
           const selectedColor = this.#getRandom(colors, true);
           column.classList.add("background-" + selectedColor);
-          column.querySelector(".group-title").classList.add("background-" + selectedColor);
         } else {
           const randomColorHex = Math.floor(Math.random()*0xFFFFFF).toString(16);
           const randomColorClass = document.createElement('style');

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -333,6 +333,10 @@ export class GroupsController {
     column.parentNode.removeAttribute("style");
   }
 
+  /**
+   * Method used to receive an array of currently available colors
+   * @returns an array with available colors (defined and currently generated)
+   */
   #getAvailableColors() {
     const definedColors = ["navy", "aqua", "green", "orange", "red", "blue", "yellow", "plum"];
     const pageHeadElement = document.getElementsByTagName('head')[0];
@@ -342,6 +346,11 @@ export class GroupsController {
     return definedColors.concat(generatedColors);
   }
 
+  /**
+   * Method used to create CSS color responsible for color style
+   * @param {String} color The color name/code/hex for which we want to generate class
+   * @returns the name of currently generated (and added to header) style class
+   */
   #createColorClass(color) {
     const className = `background-${color}`;
     const classElement = document.createElement('style');

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -350,7 +350,7 @@ export class GroupsController {
   #createColorClass(color) {
     const className = `background-${color}`;
     const classElement = document.createElement('style');
-    classElement.innerHTML = `.${className} { background: #${color}; color: black; }`;
+    classElement.innerHTML = `.${className} { background: #${color}; color: ${this.#invertColor(color)}; }`;
     document.getElementsByTagName('head')[0].appendChild(classElement);
     return className;
   }
@@ -378,5 +378,21 @@ export class GroupsController {
    */
   #getRandomColor() {
     return Math.floor(Math.random() * 0xffffff).toString(16);
+  }
+
+  #invertColor(color) {
+    if (0 === color.indexOf("#")) {
+      color = color.slice(1);
+    }
+    if (3 === color.length) {
+      color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
+    }
+    if (6 !== color.length) {
+      throw new Error(`Invalid color: ${color}`);
+    }
+    const r = parseInt(color.slice(0, 2), 16);
+    const g = parseInt(color.slice(2, 4), 16);
+    const b = parseInt(color.slice(4, 6), 16);
+    return r * 0.299 + g * 0.587 + b * 0.114 > 186 ? "black" : "white";
   }
 }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -64,7 +64,7 @@ export class GroupsController {
           column.classList.add("background-" + selectedColor);
           column.querySelector(".group-title").classList.add("background-" + selectedColor);
         } else {
-          const randomColorHex = Math.floor(Math.random()*16777215).toString(16);
+          const randomColorHex = Math.floor(Math.random()*0xFFFFFF).toString(16);
           const randomColorClass = document.createElement('style');
           randomColorClass.innerHTML = `.background-${randomColorHex} { background: #${randomColorHex}; color: black; }`;
           document.getElementsByTagName('head')[0].appendChild(randomColorClass);


### PR DESCRIPTION
This patch fixes #26 
Refactored group controller to create min number of CSS color classes with random background and black/white text color depending on the best contrast with the background.