### PR TITLE
User can add/update groups and observers which has at least one letter

### DIFF
--- a/src/model/scrap-group.js
+++ b/src/model/scrap-group.js
@@ -3,6 +3,8 @@ import { ScrapError } from "./scrap-exception.js";
 import { ScrapObserver } from "./scrap-observer.js";
 
 export class ScrapGroup {
+  static #NAME_REGEX = /[a-zA-Z]/;
+
   /**
    * Creates a new scrap group from a specified object
    * @param {Object} object The source object
@@ -45,6 +47,8 @@ export class ScrapGroup {
     const checkResult = { errors: [], warnings: [] };
     if (!this.name) {
       checkResult.errors.push("Missing required group name");
+    } else if (false === ScrapGroup.#NAME_REGEX.test(this.name)) {
+      checkResult.errors.push("Group name must have at least one letter");
     }
     if (!this.domain) {
       checkResult.errors.push("Missing required group domain");

--- a/src/model/scrap-observer.js
+++ b/src/model/scrap-observer.js
@@ -3,6 +3,7 @@ import { ScrapComponent } from "./scrap-component.js";
 import { ScrapError } from "./scrap-exception.js";
 
 export class ScrapObserver {
+  static #NAME_REGEX = /[a-zA-Z]/;
   static #TARGET_OPTIONS = ["load", "domcontentloaded", "networkidle0", "networkidle2"];
   static #HISTORY_OPTIONS = ["off", "on", "onChange"];
 
@@ -56,6 +57,8 @@ export class ScrapObserver {
     const checkResult = { errors: [], warnings: [] };
     if (!this.name) {
       checkResult.errors.push(`Missing required observer name`);
+    } else if (false === ScrapObserver.#NAME_REGEX.test(this.name)) {
+      checkResult.errors.push("Observer name must have at least one letter");
     }
     if (!this.path) {
       checkResult.errors.push(`Missing required observer path`);


### PR DESCRIPTION
This patch fixes #27 
Added name regex patter to group and observer model classes so user will add only the ones which have at least one letter in their names