### PR TITLE
Fixed missing all currencies options after reloading groups and observers

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -16,6 +16,9 @@ mediator.register(componentsController);
 mediator.register(observersController);
 mediator.register(groupsController);
 
+/**
+ * Method used to store initial backend values to session storage
+ */
 function storeInitialBackendValues() {
   const priceAuxComponent = document.querySelector("select.component-price-auxiliary");
   const currenciesOptions = priceAuxComponent.querySelectorAll("option:not([disabled])");

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -20,5 +20,5 @@ function storeInitialBackendValues() {
   const priceAuxComponent = document.querySelector("select.component-price-auxiliary");
   const currenciesOptions = priceAuxComponent.querySelectorAll("option:not([disabled])");
   const currenciesValues = Array.from(currenciesOptions).map((element) => element.value);
-  localStorage.setItem("currencies", currenciesValues);
+  sessionStorage.setItem("currencies", currenciesValues);
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3,6 +3,8 @@ import { ComponentsController } from "./controller-component.js";
 import { ObserversController } from "./controller-observer.js";
 import { GroupsController } from "./controller-group.js";
 
+// persist backend variables in frontend local storage at reload
+storeInitialBackendValues();
 // creating mediator class transmitting events between controllers
 const mediator = new ControllersMediator();
 // creating controllers objects
@@ -13,3 +15,10 @@ const groupsController = new GroupsController();
 mediator.register(componentsController);
 mediator.register(observersController);
 mediator.register(groupsController);
+
+function storeInitialBackendValues() {
+  const priceAuxComponent = document.querySelector("select.component-price-auxiliary");
+  const currenciesOptions = priceAuxComponent.querySelectorAll("option:not([disabled])");
+  const currenciesValues = Array.from(currenciesOptions).map((element) => element.value);
+  localStorage.setItem("currencies", currenciesValues);
+}

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -110,7 +110,7 @@ export class ComponentsView {
                   <div class="widget">
                     <label class="component-price-label">auxiliary:</label>
                     <select class="component-price-auxiliary" name="auxiliary" required>
-                    ${ComponentsView.#getCurrenciesOptionsHtml(auxiliary, localStorage.getItem("currencies"))}
+                    ${ComponentsView.#getCurrenciesOptionsHtml(auxiliary)}
                     </select>
                   </div>
                 </div>
@@ -118,9 +118,9 @@ export class ComponentsView {
             </div>`;
   }
 
-  static #getCurrenciesOptionsHtml(selectedCurrency, allCurrencies) {
+  static #getCurrenciesOptionsHtml(selectedCurrency) {
     let result = `<option value="" disabled hidden ${selectedCurrency === "" ? "selected" : ""}>Select value</option>`;
-    allCurrencies.split(",").forEach(currency => {
+    localStorage.getItem("currencies").split(",").forEach(currency => {
       result += `<option value=${currency} ${selectedCurrency === currency ? "selected" : ""}>${currency}</option>`;
     })
     return result;

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -118,6 +118,11 @@ export class ComponentsView {
             </div>`;
   }
 
+  /**
+   * Method used to retrieve select options with all supported currencies
+   * @param {String} selectedCurrency The currently selected currency
+   * @returns HTML code with all possible options for select tag
+   */
   static #getCurrenciesOptionsHtml(selectedCurrency) {
     let result = `<option value="" disabled hidden ${selectedCurrency === "" ? "selected" : ""}>Select value</option>`;
     sessionStorage.getItem("currencies").split(",").forEach(currency => {

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -120,7 +120,7 @@ export class ComponentsView {
 
   static #getCurrenciesOptionsHtml(selectedCurrency) {
     let result = `<option value="" disabled hidden ${selectedCurrency === "" ? "selected" : ""}>Select value</option>`;
-    localStorage.getItem("currencies").split(",").forEach(currency => {
+    sessionStorage.getItem("currencies").split(",").forEach(currency => {
       result += `<option value=${currency} ${selectedCurrency === currency ? "selected" : ""}>${currency}</option>`;
     })
     return result;

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -110,15 +110,19 @@ export class ComponentsView {
                   <div class="widget">
                     <label class="component-price-label">auxiliary:</label>
                     <select class="component-price-auxiliary" name="auxiliary" required>
-                      <option value="" disabled hidden ${auxiliary === "" ? "selected" : ""}>Select value</option>
-                      <option value=PLN ${auxiliary === "PLN" ? "selected" : ""}>PLN</option>
-                      <option value=GBP ${auxiliary === "GBP" ? "selected" : ""}>GBP</option>
-                      <option value=USD ${auxiliary === "USD" ? "selected" : ""}>USD</option>
-                      <option value=EUR ${auxiliary === "EUR" ? "selected" : ""}>EUR</option>
+                    ${ComponentsView.#getCurrenciesOptionsHtml(auxiliary, "PLN|GBP|USD|EUR|CHF|CZK|DKK|JPY|INR|AUD")}
                     </select>
                   </div>
                 </div>
               </div>
             </div>`;
+  }
+
+  static #getCurrenciesOptionsHtml(selectedCurrency, allCurrencies) {
+    let result = `<option value="" disabled hidden ${selectedCurrency === "" ? "selected" : ""}>Select value</option>`;
+    allCurrencies.split("|").forEach(currency => {
+      result += `<option value=${currency} ${selectedCurrency === currency ? "selected" : ""}>${currency}</option>`;
+    })
+    return result;
   }
 }

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -110,7 +110,7 @@ export class ComponentsView {
                   <div class="widget">
                     <label class="component-price-label">auxiliary:</label>
                     <select class="component-price-auxiliary" name="auxiliary" required>
-                    ${ComponentsView.#getCurrenciesOptionsHtml(auxiliary, "PLN|GBP|USD|EUR|CHF|CZK|DKK|JPY|INR|AUD")}
+                    ${ComponentsView.#getCurrenciesOptionsHtml(auxiliary, localStorage.getItem("currencies"))}
                     </select>
                   </div>
                 </div>
@@ -120,7 +120,7 @@ export class ComponentsView {
 
   static #getCurrenciesOptionsHtml(selectedCurrency, allCurrencies) {
     let result = `<option value="" disabled hidden ${selectedCurrency === "" ? "selected" : ""}>Select value</option>`;
-    allCurrencies.split("|").forEach(currency => {
+    allCurrencies.split(",").forEach(currency => {
       result += `<option value=${currency} ${selectedCurrency === currency ? "selected" : ""}>${currency}</option>`;
     })
     return result;

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -46,6 +46,6 @@ export class ViewRouter {
    * @returns a String with supported currencies separated by '|' character
    */
   #getSupportedCurrencies() {
-    return "PLN|GBP|USD|EUR|CHF|CZK|DKK|JPY|INR|AUD";
+    return "PLN|GBP|USD|EUR|CHF|CZK|DKK|CNY|JPY|INR|AUD|CAD";
   }
 }


### PR DESCRIPTION
This patch fixes #24 
Storing accepted/supported currencies in session storage after page reload to restore them after re-populating the whole HTML