### PR TITLE
Fixed bug with incorrect initial category dialog value

### DIFF
--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -119,8 +119,7 @@ export class GroupsController {
         }, { once: true });
         // listen to close event to setup category value (it can be either new one or restored one)
         categoryDialog.addEventListener("close", (closeEvent) => {
-          const parentCategoryButton = this.#groupExpanded.querySelector("input.group-category");
-          parentCategoryButton.value = categoryDialog.returnValue;
+          button.value = categoryDialog.returnValue;
           closeEvent.stopPropagation();
         }, { once: true });
         categoryDialog.showModal();

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -112,10 +112,12 @@ export class GroupsController {
       button.addEventListener("click", (clickEvent) => {
         const initialValue = button.value;
         const categoryDialog = document.querySelector("dialog.group-category-dialog");
+        // listen to cancel event (when ESC pressed) to restore value for current catrgory dialog
         categoryDialog.addEventListener("cancel", (cancelEvent) => {
           categoryDialog.returnValue = initialValue;
           cancelEvent.stopPropagation();
         }, { once: true });
+        // listen to close event to setup category value (it can be either new one or restored one)
         categoryDialog.addEventListener("close", (closeEvent) => {
           const parentCategoryButton = this.#groupExpanded.querySelector("input.group-category");
           parentCategoryButton.value = categoryDialog.returnValue;

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -110,7 +110,12 @@ export class GroupsController {
     const groupCategoryButtons = document.querySelectorAll("input.group-category");
     groupCategoryButtons.forEach((button) => {
       button.addEventListener("click", (clickEvent) => {
+        const initialValue = button.value;
         const categoryDialog = document.querySelector("dialog.group-category-dialog");
+        categoryDialog.addEventListener("cancel", (cancelEvent) => {
+          categoryDialog.returnValue = initialValue;
+          cancelEvent.stopPropagation();
+        }, { once: true });
         categoryDialog.addEventListener("close", (closeEvent) => {
           const parentCategoryButton = this.#groupExpanded.querySelector("input.group-category");
           parentCategoryButton.value = categoryDialog.returnValue;


### PR DESCRIPTION
This patch fixes #21 
Now when user cancels the category selection then appropriate initial value will be restored.