### PR TITLE
Cancelling restores group and observer data

### DIFF
--- a/public/css/columns.css
+++ b/public/css/columns.css
@@ -107,7 +107,7 @@
   opacity: 0;
   visibility: hidden;
   transform: translate(-50%, -50%) scale(0.5);
-  transition: all 0.6s cubic-bezier(0.23, 1, 0.32, 1);
+  transition: all 0.45s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .group-column .group-content input:disabled {

--- a/public/js/controller-common.js
+++ b/public/js/controller-common.js
@@ -4,6 +4,12 @@ export class CommonController {
   static #TYPE_SUCCESS = 0;
   static #TYPE_WARNING = 1;
 
+  static htmlToElement(string) {
+    var tempContainer = document.createElement('div');
+    tempContainer.innerHTML = string;
+    return tempContainer.firstChild;
+  }
+
   /**
    * Method used to show error toast popup (and underlying error message in console)
    * @param {String} message The message to be displayed in the toast

--- a/public/js/controller-common.js
+++ b/public/js/controller-common.js
@@ -4,6 +4,16 @@ export class CommonController {
   static #TYPE_SUCCESS = 0;
   static #TYPE_WARNING = 1;
 
+  static getGroupColumnWithName(groupName) {
+    const foundColumns = Array.from(document.querySelectorAll("article.group-column h2.group-title"))
+        .filter((element) => element.innerText === groupName)
+        .map((element) => element.closest("article.group-column"));
+    if (1 !== foundColumns.length) {
+      showToastError(`Internal error! Found ${foundColumns.length} columns with name: ${groupName}`);
+    }
+    return foundColumns[0];
+  }
+
   /**
    * Method used to convert HTML string/code to HTML element/object
    * @param {String} string The input HTML code to be converted

--- a/public/js/controller-common.js
+++ b/public/js/controller-common.js
@@ -4,12 +4,18 @@ export class CommonController {
   static #TYPE_SUCCESS = 0;
   static #TYPE_WARNING = 1;
 
+  /**
+   * Method used to find a specific group column container which has title equal to specified group name
+   * @param {String} groupName The name of the group column which we want to find
+   * @returns Group column container with title matching the name, or undefined if no container found
+   */
   static getGroupColumnWithName(groupName) {
     const foundColumns = Array.from(document.querySelectorAll("article.group-column h2.group-title"))
         .filter((element) => element.innerText === groupName)
         .map((element) => element.closest("article.group-column"));
     if (1 !== foundColumns.length) {
       showToastError(`Internal error! Found ${foundColumns.length} columns with name: ${groupName}`);
+      return undefined;
     }
     return foundColumns[0];
   }

--- a/public/js/controller-common.js
+++ b/public/js/controller-common.js
@@ -4,6 +4,11 @@ export class CommonController {
   static #TYPE_SUCCESS = 0;
   static #TYPE_WARNING = 1;
 
+  /**
+   * Method used to convert HTML string/code to HTML element/object
+   * @param {String} string The input HTML code to be converted
+   * @returns HTML element node from code
+   */
   static htmlToElement(string) {
     var tempContainer = document.createElement('div');
     tempContainer.innerHTML = string;

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -145,6 +145,7 @@ export class GroupsController {
           confirmDialog.showModal();
         } else if ("cancel" === selectedAction) {
           this.#collapse(closeButton);
+          this.#cleanGroupData();
         } else {
           CommonController.showToastError(`Unsupported accept button action: ${selectedAction}`);
         }
@@ -163,6 +164,7 @@ export class GroupsController {
       .then((data) => {
         this.#reloadGroups(parentUserId);
         this.#collapse(closeButton);
+        this.#cleanGroupData();
         CommonController.showToastSuccess(data);
       })
       .catch((error) => {
@@ -181,6 +183,7 @@ export class GroupsController {
     GroupsService.updateGroup(editedGroupId)
       .then((data) => {
         this.#collapse(closeButton);
+        this.#cleanGroupData();
         CommonController.showToastSuccess(data);
       })
       .catch((error) => {
@@ -200,6 +203,7 @@ export class GroupsController {
       .then((data) => {
         this.#reloadGroups(0);
         this.#collapse(closeButton);
+        this.#cleanGroupData();
         CommonController.showToastSuccess(data);
       })
       .catch((error) => {
@@ -280,7 +284,6 @@ export class GroupsController {
         }
       });
       groupCloseButton.classList.remove("show");
-      this.#groupExpanded = undefined;
       // notify other controllers that none group is expanded
       this.emitEvent("group-expanded", undefined);
     }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -262,7 +262,7 @@ export class GroupsController {
         column.parentNode.classList.add(column === groupColumn ? "expanded" : "collapsed");
         this.#clearDimension(column);
       });
-      this.#groupExpanded = GroupsView.fromHtml(groupColumn.parentNode);
+      this.#storeGroupData(groupColumn.parentNode);
       // notify other controllers that group with specified name was expanded
       this.emitEvent("group-expanded", groupColumn.querySelector("h2.group-title").innerText);
     }
@@ -425,6 +425,10 @@ export class GroupsController {
     const g = parseInt(color.slice(2, 4), 16);
     const b = parseInt(color.slice(4, 6), 16);
     return r * 0.299 + g * 0.587 + b * 0.114 > 186 ? "black" : "white";
+  }
+
+  #storeGroupData(groupTarget) {
+    this.#groupExpanded = GroupsView.fromHtml(groupTarget);
   }
 
   #cleanGroupData() {

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -145,7 +145,7 @@ export class GroupsController {
           confirmDialog.showModal();
         } else if ("cancel" === selectedAction) {
           this.#collapse(closeButton);
-          this.#cleanGroupData();
+          this.#restoreGroupData(closeButton);
         } else {
           CommonController.showToastError(`Unsupported accept button action: ${selectedAction}`);
         }
@@ -432,6 +432,11 @@ export class GroupsController {
   }
 
   #cleanGroupData() {
+    this.#groupExpanded = undefined;
+  }
+
+  #restoreGroupData(groupTarget) {
+    const parentContainer = groupTarget.closest("article.group-column");
     this.#groupExpanded = undefined;
   }
 }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -479,7 +479,11 @@ export class GroupsController {
       .findIndex((name) => name === this.#groupExpanded.name);
     const restoredElement = CommonController.htmlToElement(GroupsView.toHtml(this.#groupExpanded));
     const previousElement = childIndex < 0 ? parentContainer.lastElementChild : parentContainer.children[childIndex];
-    parentContainer.replaceChild(restoredElement, previousElement);
+    // restore child elements to keep group collapse animation continuity
+    const restoreChildren = ["div.group-root-data", "div.group-observers"];
+    restoreChildren.forEach((childSelector) => {
+      previousElement.querySelector(childSelector).innerHTML = restoredElement.querySelector(childSelector).innerHTML;
+    });
     this.#groupExpanded = undefined;
     // re-initialize group controller for all groups (including the replaced one)
     this.#initController(restoredElement.querySelector("div.group-container"));

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -74,7 +74,6 @@ export class GroupsController {
       } else {
         // new group column should always appear from right and have gray background
         column.classList.add("background-violet");
-        column.querySelector(".group-title").classList.add("background-violet");
         column.classList.add("column-from-right");
         // if new group is the only group then show its label, else hide the label
         if (this.#groupColumns.length < 2) {

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -423,4 +423,8 @@ export class GroupsController {
     const b = parseInt(color.slice(4, 6), 16);
     return r * 0.299 + g * 0.587 + b * 0.114 > 186 ? "black" : "white";
   }
+
+  #cleanGroupData() {
+    this.#groupExpanded = undefined;
+  }
 }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -69,8 +69,12 @@ export class GroupsController {
               ? "background-" + this.#getRandomElement(colors, true)
               : this.#createColorClass(this.#getRandomColor()));
         }
-        // get animation from array (duplicates are allowed in this case)
-        column.classList.add(this.#getRandomElement(animations, false));
+        // add animation class only when current column does not have it already (possible when restoring group)
+        const hasAnimationClass = (className) => className.startsWith("column-from-");
+        if (!columnClasses.filter(hasAnimationClass).length) {
+          // get animation from array (duplicates are allowed in this case)
+          column.classList.add(this.#getRandomElement(animations, false));
+        }
       } else {
         // new group column should always appear from right and have gray background
         column.classList.add("background-violet");

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -440,7 +440,13 @@ export class GroupsController {
   }
 
   #restoreGroupData(groupTarget) {
-    const parentContainer = groupTarget.closest("article.group-column");
+    const parentContainer = groupTarget.closest("section.group-columns");
+    const childIndex = Array.from(parentContainer.children)
+      .map((element) => element.querySelector("h2.group-title").innerText)
+      .findIndex((name) => name === this.#groupExpanded.name);
+    const restoredElement = CommonController.htmlToElement(GroupsView.toHtml(this.#groupExpanded));
+    const previousElement = childIndex < 0 ? parentContainer.lastElementChild : parentContainer.children[childIndex];
+    parentContainer.replaceChild(restoredElement, previousElement);
     this.#groupExpanded = undefined;
   }
 }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -93,7 +93,8 @@ export class GroupsController {
    * This method handles: group column and close column buttons clicks & new column hint
    */
   #bindListeners(groupContainer = undefined) {
-    this.#groupColumns.forEach((column) => {
+    const columns = groupContainer === undefined ? this.#groupColumns : [groupContainer];
+    columns.forEach((column) => {
       column.addEventListener("click", (event) => {
         this.#expand(column);
         event.stopPropagation();

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -480,12 +480,12 @@ export class GroupsController {
     const restoredElement = CommonController.htmlToElement(GroupsView.toHtml(this.#groupExpanded));
     const previousElement = childIndex < 0 ? parentContainer.lastElementChild : parentContainer.children[childIndex];
     // restore child elements to keep group collapse animation continuity
-    const restoreChildren = ["div.group-root-data", "div.group-observers"];
+    const restoreChildren = ["div.group-root-data", "div.group-observers", "div.group-buttons"];
     restoreChildren.forEach((childSelector) => {
       previousElement.querySelector(childSelector).innerHTML = restoredElement.querySelector(childSelector).innerHTML;
     });
-    // re-initialize group controller for all groups (including the replaced one)
-    this.#initController(restoredElement.querySelector("div.group-container"));
+    // re-initialize controller for all groups (but bind listeners only for the restored one)
+    this.#initController(previousElement.querySelector("div.group-container"));
     // notify other controllers that groups were reloaded
     this.emitEvent("group-restored", this.#groupExpanded.name);
     // clean stored group data

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -435,6 +435,10 @@ export class GroupsController {
     return r * 0.299 + g * 0.587 + b * 0.114 > 186 ? "black" : "white";
   }
 
+  /**
+   * Method used to save specified group's data
+   * @param {Object} groupTarget The group which data we want to store
+   */
   #storeGroupData(groupTarget) {
     this.#groupExpanded = GroupsView.fromHtml(groupTarget);
     // if stored group does not have a name then it's a new one = we have to remember the user ID
@@ -443,10 +447,17 @@ export class GroupsController {
     }
   }
 
+  /**
+   * Method used to clean saved group data
+   */
   #cleanGroupData() {
     this.#groupExpanded = undefined;
   }
 
+  /**
+   * Method used to restore values saved earlier for specified group target
+   * @param {Object} groupTarget The group which values we want to restore
+   */
   #restoreGroupData(groupTarget) {
     const parentContainer = groupTarget.closest("section.group-columns");
     const childIndex = Array.from(parentContainer.children)

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -448,5 +448,9 @@ export class GroupsController {
     const previousElement = childIndex < 0 ? parentContainer.lastElementChild : parentContainer.children[childIndex];
     parentContainer.replaceChild(restoredElement, previousElement);
     this.#groupExpanded = undefined;
+    // re-initialize group controller for all groups (including the replaced one)
+    this.#initController();
+    // notify other controllers that groups were reloaded
+    this.emitEvent("groups-reloaded", undefined);
   }
 }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -40,6 +40,8 @@ export class GroupsController {
 
   /**
    * Method used to (re)initialize controller
+   * @param {Element} groupContainer The concrete group container to initialize (listeners binding only).
+   *                                 If not specified then ALL group containers will be initialized.
    */
   #initController(groupContainer = undefined) {
     // get all elements representing group columns
@@ -89,8 +91,9 @@ export class GroupsController {
   }
 
   /**
-   * Method used to bind UI listeners to controller methods.
-   * This method handles: group column and close column buttons clicks & new column hint
+   * Method used to bind open, close and new group hint listeners to controller methods.
+   * @param {Element} groupContainer The concrete group container to bind listeners.
+   *                                 If not specified then ALL group containers will have listeners binded.
    */
   #bindListeners(groupContainer = undefined) {
     const columns = groupContainer === undefined ? this.#groupColumns : [groupContainer];

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -41,13 +41,13 @@ export class GroupsController {
   /**
    * Method used to (re)initialize controller
    */
-  #initController() {
+  #initController(groupContainer = undefined) {
     // get all elements representing group columns
     this.#groupColumns = document.querySelectorAll(".group-column > .group-container");
     // initialize style, size, and logic of all group columns
     this.#initStyle();
     this.#initDimensions();
-    this.#bindListeners();
+    this.#bindListeners(groupContainer);
   }
 
   /**
@@ -92,7 +92,7 @@ export class GroupsController {
    * Method used to bind UI listeners to controller methods.
    * This method handles: group column and close column buttons clicks & new column hint
    */
-  #bindListeners() {
+  #bindListeners(groupContainer = undefined) {
     this.#groupColumns.forEach((column) => {
       column.addEventListener("click", (event) => {
         this.#expand(column);
@@ -449,7 +449,7 @@ export class GroupsController {
     parentContainer.replaceChild(restoredElement, previousElement);
     this.#groupExpanded = undefined;
     // re-initialize group controller for all groups (including the replaced one)
-    this.#initController();
+    this.#initController(restoredElement.querySelector("div.group-container"));
     // notify other controllers that groups were reloaded
     this.emitEvent("groups-reloaded", undefined);
   }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -429,6 +429,10 @@ export class GroupsController {
 
   #storeGroupData(groupTarget) {
     this.#groupExpanded = GroupsView.fromHtml(groupTarget);
+    // if stored group does not have a name then it's a new one = we have to remember the user ID
+    if (!this.#groupExpanded.name) {
+      this.#groupExpanded = 0;
+    }
   }
 
   #cleanGroupData() {

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -127,7 +127,9 @@ export class GroupsController {
         clickEvent.stopPropagation();
       });
     });
-    const groupCloseButtons = document.querySelectorAll(".group-buttons > .group-close-btn");
+    const groupCloseButtons = groupContainer === undefined
+        ? document.querySelectorAll(".group-buttons > .group-close-btn")
+        : groupContainer.querySelectorAll(".group-buttons > .group-close-btn");
     groupCloseButtons.forEach((closeButton) => {
       closeButton.addEventListener("click", (clickEvent) => {
         const target = clickEvent.currentTarget;

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -108,7 +108,9 @@ export class GroupsController {
         event.stopPropagation();
       });
     });
-    const groupCategoryButtons = document.querySelectorAll("input.group-category");
+    const groupCategoryButtons = groupContainer === undefined
+        ? document.querySelectorAll("input.group-category")
+        : groupContainer.querySelectorAll("input.group-category");
     groupCategoryButtons.forEach((button) => {
       button.addEventListener("click", (clickEvent) => {
         const initialValue = button.value;

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -380,7 +380,13 @@ export class GroupsController {
     const generatedColors = Array.from(pageHeadElement.getElementsByTagName("style")).map((element) => {
       return element.innerHTML.match(".background-([0-9a-fA-F]+)")[1];
     });
-    return definedColors.concat(generatedColors);
+    // retrieve any color that is already in use (possible after restoring expanded group)
+    const usedColors = Array.from(this.#groupColumns)
+      .filter((column) => "update" === column.dataset.action)
+      .flatMap((column) => Array.from(column.classList))
+      .filter((className) => className.startsWith("background-"))
+      .map((className) => className.substring("background-".length));
+    return definedColors.concat(generatedColors).filter((color) => !usedColors.includes(color));
   }
 
   /**

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -112,14 +112,12 @@ export class GroupsController {
       button.addEventListener("click", (clickEvent) => {
         const initialValue = button.value;
         const categoryDialog = document.querySelector("dialog.group-category-dialog");
-        // listen to cancel event (when ESC pressed) to restore value for current catrgory dialog
-        categoryDialog.addEventListener("cancel", (cancelEvent) => {
-          categoryDialog.returnValue = initialValue;
-          cancelEvent.stopPropagation();
-        }, { once: true });
-        // listen to close event to setup category value (it can be either new one or restored one)
+        // update current initial value to dialog's value to detect update/cancel state
+        categoryDialog.returnValue = initialValue;
         categoryDialog.addEventListener("close", (closeEvent) => {
-          button.value = categoryDialog.returnValue;
+          // when user closes dialog via ESC button then return value will be empty
+          const selectedValue = categoryDialog.returnValue;
+          button.value = "" === selectedValue ? initialValue : selectedValue;
           closeEvent.stopPropagation();
         }, { once: true });
         categoryDialog.showModal();

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -484,10 +484,11 @@ export class GroupsController {
     restoreChildren.forEach((childSelector) => {
       previousElement.querySelector(childSelector).innerHTML = restoredElement.querySelector(childSelector).innerHTML;
     });
-    this.#groupExpanded = undefined;
     // re-initialize group controller for all groups (including the replaced one)
     this.#initController(restoredElement.querySelector("div.group-container"));
     // notify other controllers that groups were reloaded
-    this.emitEvent("groups-reloaded", undefined);
+    this.emitEvent("group-restored", this.#groupExpanded.name);
+    // clean stored group data
+    this.#cleanGroupData();
   }
 }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -60,10 +60,15 @@ export class GroupsController {
     const animations = ["column-from-top", "column-from-right", "column-from-bottom", "column-from-left"];
     this.#groupColumns.forEach((column) => {
       if ("update" === column.dataset.action) {
-        // get color from array and then remove it so no duplicates are selected (in next iterations)
-        column.classList.add(colors.length > 0
-            ? "background-" + this.#getRandomElement(colors, true)
-            : this.#createColorClass(this.#getRandomColor()));
+        const columnClasses = Array.from(column.classList);
+        // add color class only when current column does not have it already (possible when restoring group)
+        const hasColorClass = (className) => className.startsWith("background-");
+        if (!columnClasses.filter(hasColorClass).length) {
+          // get color from array and then remove it so no duplicates are selected (in next iterations)
+          column.classList.add(colors.length > 0
+              ? "background-" + this.#getRandomElement(colors, true)
+              : this.#createColorClass(this.#getRandomColor()));
+        }
         // get animation from array (duplicates are allowed in this case)
         column.classList.add(this.#getRandomElement(animations, false));
       } else {

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -258,7 +258,7 @@ export class GroupsController {
         column.parentNode.classList.add(column === groupColumn ? "expanded" : "collapsed");
         this.#clearDimension(column);
       });
-      this.#groupExpanded = groupColumn.parentNode;
+      this.#groupExpanded = GroupsView.fromHtml(groupColumn.parentNode);
       // notify other controllers that group with specified name was expanded
       this.emitEvent("group-expanded", groupColumn.querySelector("h2.group-title").innerText);
     }

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -69,7 +69,7 @@ export class ObserversController {
       observerDialog.classList.remove("hidden");
       observerDialog.classList.add("init-reveal");
       event.stopPropagation();
-      this.#storeOpenedObserver(target);
+      this.#storeObserverData(target);
     });
   }
 
@@ -97,7 +97,7 @@ export class ObserversController {
         confirmDialog.showModal();
       } else if ("cancel" === selectedAction) {
         this.#hideDialog(closeButton);
-        this.#restoreOpenedObserver(target);
+        this.#restoreObserverData(target);
       } else {
         CommonController.showToastError(`Unsupported accept button action: ${selectedAction}`);
       }
@@ -115,7 +115,7 @@ export class ObserversController {
       .then((data) => {
         this.#reloadObservers(parentGroupId);
         this.#hideDialog(closeButton);
-        this.#clearOpenedObserver();
+        this.#clearObserverData();
         CommonController.showToastSuccess(data);
       })
       .catch((error) => {
@@ -134,7 +134,7 @@ export class ObserversController {
     ObserversService.updateObserver(editedObserverId)
       .then((data) => {
         this.#hideDialog(closeButton);
-        this.#clearOpenedObserver();
+        this.#clearObserverData();
         CommonController.showToastSuccess(data);
       })
       .catch((error) => {
@@ -154,7 +154,7 @@ export class ObserversController {
       .then((data) => {
         this.#reloadObservers(this.#expandedGroup);
         this.#hideDialog(closeButton);
-        this.#clearOpenedObserver();
+        this.#clearObserverData();
         CommonController.showToastSuccess(data);
       })
       .catch((error) => {
@@ -200,7 +200,7 @@ export class ObserversController {
    * Method used to save specified observer's data
    * @param {Object} observerTarget The observer which data we want to store
    */
-  #storeOpenedObserver(observerTarget) {
+  #storeObserverData(observerTarget) {
     this.#openedObserver = ObserversView.fromHtml(observerTarget.parentNode);
     // if stored observer does not have a name then it's a new one = we have to remember the parent ID
     if (!this.#openedObserver.name) {
@@ -211,7 +211,7 @@ export class ObserversController {
   /**
    * Method used to clean saved observer data
    */
-  #clearOpenedObserver() {
+  #clearObserverData() {
     this.#openedObserver = undefined;
   }
 
@@ -219,7 +219,7 @@ export class ObserversController {
    * Method used to restore values saved earlier for specified observer target
    * @param {Object} observerTarget The observer which values we want to restore
    */
-  #restoreOpenedObserver(observerTarget) {
+  #restoreObserverData(observerTarget) {
     // update current target values with the restored ones
     const parentContainer = observerTarget.closest("div.observers-container");
     const childIndex = Array.from(parentContainer.children)
@@ -228,7 +228,7 @@ export class ObserversController {
     const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
     const previousElement = childIndex < 0 ? parentContainer.lastElementChild : parentContainer.children[childIndex];
     parentContainer.replaceChild(restoredElement, previousElement);
-    this.#clearOpenedObserver();
+    this.#clearObserverData();
     // bind open and close listeners to the newly updated/restored element
     this.#bindOpenDialogListener(restoredElement.querySelector(`div.modal-button`));
     restoredElement.querySelectorAll(`div.modal-close-btn`).forEach((btn) => this.#bindCloseDialogListener(btn));

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -55,10 +55,10 @@ export class ObserversController {
    *                               If not used then this will affect ALL observer buttons/dialogs.
    */
   #bindListeners(parentGroupId = undefined) {
-    const parentGroupSelector = parentGroupId ? ".group-column.expanded " : "";
-    const observerButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-button`);
+    const parentElement = parentGroupId ? CommonController.getGroupColumnWithName(parentGroupId) : document;
+    const observerButtons = parentElement.querySelectorAll("div.modal-button");
     observerButtons.forEach((button) => this.#bindOpenDialogListener(button));
-    const modalCloseButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-close-btn`);
+    const modalCloseButtons = parentElement.querySelectorAll("div.modal-close-btn");
     modalCloseButtons.forEach((button) => this.#bindCloseDialogListener(button));
   }
 

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -58,6 +58,10 @@ export class ObserversController {
     modalCloseButtons.forEach((button) => this.#addCloseDialogListener(button));
   }
 
+  /**
+   * Method used to add open dialog action listeners to observers buttons
+   * @param {Element} openButton The observer button which should be able to open observer dialog
+   */
   #addOpenDialogListener(openButton) {
     openButton.addEventListener("click", (event) => {
       const target = event.currentTarget;
@@ -73,6 +77,10 @@ export class ObserversController {
     });
   }
 
+  /**
+   * Method used to add close dialog action listeners to observer dialog buttons
+   * @param {Element} closeButton The dialog button which should be able to close observer dialog
+   */
   #addCloseDialogListener(closeButton) {
     closeButton.addEventListener("click", (clickEvent) => {
       const target = clickEvent.currentTarget;

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -97,23 +97,7 @@ export class ObserversController {
         confirmDialog.showModal();
       } else if ("cancel" === selectedAction) {
         this.#hideDialog(closeButton);
-        // restore edited observed data after cancelling operation
-        const parentContainer = target.closest("div.observers-container");
-        const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
-        const index = Array.from(parentContainer.children)
-          .map((element) => element.querySelector("div.modal-button").innerText)
-          .findIndex((name) => name === this.#openedObserver.name);
-        const previousElement = index < 0 ? parentContainer.lastElementChild : parentContainer.children[index];
-        parentContainer.replaceChild(restoredElement, previousElement);
-        // bind open and close listeners to the newly updated/restored element
-        const observerButton = restoredElement.querySelector(`div.modal-button`);
-        this.#bindOpenDialogListener(observerButton);
-        const modalCloseButtons = restoredElement.querySelectorAll(`div.modal-close-btn`);
-        modalCloseButtons.forEach((button) => this.#bindCloseDialogListener(button));
-        // notify components controller that observers were changed
-        this.emitEvent("observers-reloaded", undefined);
-        // clean previously opened observer data
-        this.#openedObserver = undefined;
+        this.#restoreOpenedObserver(target);
       } else {
         CommonController.showToastError(`Unsupported accept button action: ${selectedAction}`);
       }
@@ -222,5 +206,24 @@ export class ObserversController {
 
   #clearOpenedObserver() {
     this.#openedObserver = undefined;
+  }
+
+  #restoreOpenedObserver(observerTarget) {
+    // update current target values with the restored ones
+    const parentContainer = observerTarget.closest("div.observers-container");
+    const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
+    const index = Array.from(parentContainer.children)
+      .map((element) => element.querySelector("div.modal-button").innerText)
+      .findIndex((name) => name === this.#openedObserver.name);
+    const previousElement = index < 0 ? parentContainer.lastElementChild : parentContainer.children[index];
+    parentContainer.replaceChild(restoredElement, previousElement);
+    this.#clearOpenedObserver();
+    // bind open and close listeners to the newly updated/restored element
+    const observerButton = restoredElement.querySelector(`div.modal-button`);
+    this.#bindOpenDialogListener(observerButton);
+    const modalCloseButtons = restoredElement.querySelectorAll(`div.modal-close-btn`);
+    modalCloseButtons.forEach((button) => this.#bindCloseDialogListener(button));
+    // notify other controller(s) that observer(s) were changed
+    this.emitEvent("observers-reloaded", undefined);
   }
 }

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -132,9 +132,8 @@ export class ObserversController {
         // close observer dialog and show confirmation
         this.#reloadObservers(parentGroupId);
         this.#hideDialog(closeButton);
+        this.#clearOpenedObserver();
         CommonController.showToastSuccess(data);
-        // clean previously opened observer data
-        this.#openedObserver = undefined;
       })
       .catch((error) => {
         closeButton.classList.add("shake");
@@ -153,9 +152,8 @@ export class ObserversController {
       .then((data) => {
         // close observer dialog and show confirmation
         this.#hideDialog(closeButton);
+        this.#clearOpenedObserver();
         CommonController.showToastSuccess(data);
-        // clean previously opened observer data
-        this.#openedObserver = undefined;
       })
       .catch((error) => {
         closeButton.classList.add("shake");
@@ -175,9 +173,8 @@ export class ObserversController {
         // close observer dialog and show confirmation
         this.#reloadObservers(this.#expandedGroup);
         this.#hideDialog(closeButton);
+        this.#clearOpenedObserver();
         CommonController.showToastSuccess(data);
-        // clean previously opened observer data
-        this.#openedObserver = undefined;
       })
       .catch((error) => {
         closeButton.classList.add("shake");
@@ -223,5 +220,9 @@ export class ObserversController {
     if (!this.#openedObserver.name) {
       this.#openedObserver = this.#expandedGroup;
     }
+  }
+
+  #clearOpenedObserver() {
+    this.#openedObserver = undefined;
   }
 }

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -109,8 +109,13 @@ export class ObserversController {
           .findIndex((name) => name === this.#openedObserver.name);
         const previousElement = index < 0 ? parentContainer.lastElementChild : parentContainer.children[index];
         parentContainer.replaceChild(restoredElement, previousElement);
-        // re-bind listeners of the changed group
-        this.#bindListeners(this.#expandedGroup);
+        // bind open and close listeners to the newly updated/restored element
+        const observerButton = restoredElement.querySelector(`div.modal-button`);
+        this.#addOpenDialogListener(observerButton);
+        const modalCloseButtons = restoredElement.querySelectorAll(`div.modal-close-btn`);
+        modalCloseButtons.forEach((button) => this.#addCloseDialogListener(button));
+        // notify components controller that observers were changed
+        this.emitEvent("observers-reloaded", undefined);
         // clean previously opened observer data
         this.#openedObserver = undefined;
       } else {

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -211,18 +211,16 @@ export class ObserversController {
   #restoreOpenedObserver(observerTarget) {
     // update current target values with the restored ones
     const parentContainer = observerTarget.closest("div.observers-container");
-    const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
-    const index = Array.from(parentContainer.children)
+    const childIndex = Array.from(parentContainer.children)
       .map((element) => element.querySelector("div.modal-button").innerText)
       .findIndex((name) => name === this.#openedObserver.name);
-    const previousElement = index < 0 ? parentContainer.lastElementChild : parentContainer.children[index];
+    const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
+    const previousElement = childIndex < 0 ? parentContainer.lastElementChild : parentContainer.children[childIndex];
     parentContainer.replaceChild(restoredElement, previousElement);
     this.#clearOpenedObserver();
     // bind open and close listeners to the newly updated/restored element
-    const observerButton = restoredElement.querySelector(`div.modal-button`);
-    this.#bindOpenDialogListener(observerButton);
-    const modalCloseButtons = restoredElement.querySelectorAll(`div.modal-close-btn`);
-    modalCloseButtons.forEach((button) => this.#bindCloseDialogListener(button));
+    this.#bindOpenDialogListener(restoredElement.querySelector(`div.modal-button`));
+    restoredElement.querySelectorAll(`div.modal-close-btn`).forEach((btn) => this.#bindCloseDialogListener(btn));
     // notify other controller(s) that observer(s) were changed
     this.emitEvent("observers-reloaded", undefined);
   }

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -62,6 +62,9 @@ export class ObserversController {
         event.stopPropagation();
         // store initial HTML values of the selected observer
         this.#openedObserver = ObserversView.fromHtml(target.parentNode);
+        if (!this.#openedObserver.name) {
+          this.#openedObserver = this.#expandedGroup;
+        }
       });
     });
     const modalCloseButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-close-btn`);

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -85,6 +85,8 @@ export class ObserversController {
           confirmDialog.showModal();
         } else if ("cancel" === selectedAction) {
           this.#hideDialog(closeButton);
+          // clean previously opened observer data
+          this.#openedObserver = undefined;
         } else {
           CommonController.showToastError(`Unsupported accept button action: ${selectedAction}`);
         }
@@ -101,9 +103,12 @@ export class ObserversController {
   #addObserver(closeButton, parentGroupId) {
     ObserversService.addObserver(parentGroupId)
       .then((data) => {
+        // close observer dialog and show confirmation
         this.#reloadObservers(parentGroupId);
         this.#hideDialog(closeButton);
         CommonController.showToastSuccess(data);
+        // clean previously opened observer data
+        this.#openedObserver = undefined;
       })
       .catch((error) => {
         closeButton.classList.add("shake");
@@ -120,8 +125,11 @@ export class ObserversController {
   #updateObserver(closeButton, editedObserverId) {
     ObserversService.updateObserver(editedObserverId)
       .then((data) => {
+        // close observer dialog and show confirmation
         this.#hideDialog(closeButton);
         CommonController.showToastSuccess(data);
+        // clean previously opened observer data
+        this.#openedObserver = undefined;
       })
       .catch((error) => {
         closeButton.classList.add("shake");
@@ -138,9 +146,12 @@ export class ObserversController {
   #deleteObserver(closeButton, deletedObserverId) {
     ObserversService.deleteObserver(deletedObserverId)
       .then((data) => {
+        // close observer dialog and show confirmation
         this.#reloadObservers(this.#expandedGroup);
         this.#hideDialog(closeButton);
         CommonController.showToastSuccess(data);
+        // clean previously opened observer data
+        this.#openedObserver = undefined;
       })
       .catch((error) => {
         closeButton.classList.add("shake");

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -69,11 +69,7 @@ export class ObserversController {
       observerDialog.classList.remove("hidden");
       observerDialog.classList.add("init-reveal");
       event.stopPropagation();
-      // store initial HTML values of the selected observer
-      this.#openedObserver = ObserversView.fromHtml(target.parentNode);
-      if (!this.#openedObserver.name) {
-        this.#openedObserver = this.#expandedGroup;
-      }
+      this.#storeOpenedObserver(target);
     });
   }
 
@@ -220,5 +216,12 @@ export class ObserversController {
   #hideDialog(observerCloseButton) {
     const observerDialog = observerCloseButton.parentNode.parentNode.parentNode.parentNode;
     observerDialog.classList.add("hidden");
+  }
+
+  #storeOpenedObserver(observerTarget) {
+    this.#openedObserver = ObserversView.fromHtml(observerTarget.parentNode);
+    if (!this.#openedObserver.name) {
+      this.#openedObserver = this.#expandedGroup;
+    }
   }
 }

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -53,20 +53,7 @@ export class ObserversController {
   #bindListeners(parentGroupId = undefined) {
     const parentGroupSelector = parentGroupId ? ".group-column.expanded " : "";
     const observerButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-button`);
-    observerButtons.forEach((button) => {
-      button.addEventListener("click", (event) => {
-        const target = event.currentTarget;
-        const observerDialog = target.parentNode.querySelector("div.modal-dialog");
-        observerDialog.classList.remove("hidden");
-        observerDialog.classList.add("init-reveal");
-        event.stopPropagation();
-        // store initial HTML values of the selected observer
-        this.#openedObserver = ObserversView.fromHtml(target.parentNode);
-        if (!this.#openedObserver.name) {
-          this.#openedObserver = this.#expandedGroup;
-        }
-      });
-    });
+    observerButtons.forEach((button) => this.#addOpenDialogListener(button));
     const modalCloseButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-close-btn`);
     modalCloseButtons.forEach((closeButton) => {
       closeButton.addEventListener("click", (clickEvent) => {
@@ -105,6 +92,20 @@ export class ObserversController {
         }
         clickEvent.stopPropagation();
       });
+  }
+
+  #addOpenDialogListener(openButton) {
+    openButton.addEventListener("click", (event) => {
+      const target = event.currentTarget;
+      const observerDialog = target.parentNode.querySelector("div.modal-dialog");
+      observerDialog.classList.remove("hidden");
+      observerDialog.classList.add("init-reveal");
+      event.stopPropagation();
+      // store initial HTML values of the selected observer
+      this.#openedObserver = ObserversView.fromHtml(target.parentNode);
+      if (!this.#openedObserver.name) {
+        this.#openedObserver = this.#expandedGroup;
+      }
     });
   }
 

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -53,16 +53,16 @@ export class ObserversController {
   #bindListeners(parentGroupId = undefined) {
     const parentGroupSelector = parentGroupId ? ".group-column.expanded " : "";
     const observerButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-button`);
-    observerButtons.forEach((button) => this.#addOpenDialogListener(button));
+    observerButtons.forEach((button) => this.#bindOpenDialogListener(button));
     const modalCloseButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-close-btn`);
-    modalCloseButtons.forEach((button) => this.#addCloseDialogListener(button));
+    modalCloseButtons.forEach((button) => this.#bindCloseDialogListener(button));
   }
 
   /**
    * Method used to add open dialog action listeners to observers buttons
    * @param {Element} openButton The observer button which should be able to open observer dialog
    */
-  #addOpenDialogListener(openButton) {
+  #bindOpenDialogListener(openButton) {
     openButton.addEventListener("click", (event) => {
       const target = event.currentTarget;
       const observerDialog = target.parentNode.querySelector("div.modal-dialog");
@@ -81,7 +81,7 @@ export class ObserversController {
    * Method used to add close dialog action listeners to observer dialog buttons
    * @param {Element} closeButton The dialog button which should be able to close observer dialog
    */
-  #addCloseDialogListener(closeButton) {
+  #bindCloseDialogListener(closeButton) {
     closeButton.addEventListener("click", (clickEvent) => {
       const target = clickEvent.currentTarget;
       const selectedAction = target.dataset.action;
@@ -111,9 +111,9 @@ export class ObserversController {
         parentContainer.replaceChild(restoredElement, previousElement);
         // bind open and close listeners to the newly updated/restored element
         const observerButton = restoredElement.querySelector(`div.modal-button`);
-        this.#addOpenDialogListener(observerButton);
+        this.#bindOpenDialogListener(observerButton);
         const modalCloseButtons = restoredElement.querySelectorAll(`div.modal-close-btn`);
-        modalCloseButtons.forEach((button) => this.#addCloseDialogListener(button));
+        modalCloseButtons.forEach((button) => this.#bindCloseDialogListener(button));
         // notify components controller that observers were changed
         this.emitEvent("observers-reloaded", undefined);
         // clean previously opened observer data

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -196,6 +196,10 @@ export class ObserversController {
     observerDialog.classList.add("hidden");
   }
 
+  /**
+   * Method used to save specified observer's data
+   * @param {Object} observerTarget The observer which data we want to store
+   */
   #storeOpenedObserver(observerTarget) {
     this.#openedObserver = ObserversView.fromHtml(observerTarget.parentNode);
     // if stored observer does not have a name then it's a new one = we have to remember the parent ID
@@ -204,10 +208,17 @@ export class ObserversController {
     }
   }
 
+  /**
+   * Method used to clean saved observer data
+   */
   #clearOpenedObserver() {
     this.#openedObserver = undefined;
   }
 
+  /**
+   * Method used to restore values saved earlier for specified observer target
+   * @param {Object} observerTarget The observer which values we want to restore
+   */
   #restoreOpenedObserver(observerTarget) {
     // update current target values with the restored ones
     const parentContainer = observerTarget.closest("div.observers-container");

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -129,7 +129,6 @@ export class ObserversController {
   #addObserver(closeButton, parentGroupId) {
     ObserversService.addObserver(parentGroupId)
       .then((data) => {
-        // close observer dialog and show confirmation
         this.#reloadObservers(parentGroupId);
         this.#hideDialog(closeButton);
         this.#clearOpenedObserver();
@@ -150,7 +149,6 @@ export class ObserversController {
   #updateObserver(closeButton, editedObserverId) {
     ObserversService.updateObserver(editedObserverId)
       .then((data) => {
-        // close observer dialog and show confirmation
         this.#hideDialog(closeButton);
         this.#clearOpenedObserver();
         CommonController.showToastSuccess(data);
@@ -170,7 +168,6 @@ export class ObserversController {
   #deleteObserver(closeButton, deletedObserverId) {
     ObserversService.deleteObserver(deletedObserverId)
       .then((data) => {
-        // close observer dialog and show confirmation
         this.#reloadObservers(this.#expandedGroup);
         this.#hideDialog(closeButton);
         this.#clearOpenedObserver();
@@ -217,6 +214,7 @@ export class ObserversController {
 
   #storeOpenedObserver(observerTarget) {
     this.#openedObserver = ObserversView.fromHtml(observerTarget.parentNode);
+    // if stored observer does not have a name then it's a new one = we have to remember the parent ID
     if (!this.#openedObserver.name) {
       this.#openedObserver = this.#expandedGroup;
     }

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -89,9 +89,15 @@ export class ObserversController {
         } else if ("cancel" === selectedAction) {
           this.#hideDialog(closeButton);
           // restore edited observed data after cancelling operation
-          const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
           const parentContainer = target.closest("div.observers-container");
-          parentContainer.replaceChild(restoredElement, parentContainer.lastElementChild);
+          const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
+          const index = Array.from(parentContainer.children)
+            .map((element) => element.querySelector("div.modal-button").innerText)
+            .findIndex((name) => name === this.#openedObserver.name);
+          const previousElement = index < 0 ? parentContainer.lastElementChild : parentContainer.children[index];
+          parentContainer.replaceChild(restoredElement, previousElement);
+          // re-bind listeners of the changed group
+          this.#bindListeners(this.#expandedGroup);
           // clean previously opened observer data
           this.#openedObserver = undefined;
         } else {

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -55,43 +55,7 @@ export class ObserversController {
     const observerButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-button`);
     observerButtons.forEach((button) => this.#addOpenDialogListener(button));
     const modalCloseButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-close-btn`);
-    modalCloseButtons.forEach((closeButton) => {
-      closeButton.addEventListener("click", (clickEvent) => {
-        const target = clickEvent.currentTarget;
-        const selectedAction = target.dataset.action;
-        if ("add" === selectedAction) {
-          this.#addObserver(closeButton, target.dataset.id);
-        } else if ("update" === selectedAction) {
-          this.#updateObserver(closeButton, target.dataset.id);
-        } else if ("delete" === selectedAction) {
-          const confirmDialog = document.querySelector("dialog.delete-observer-dialog");
-          confirmDialog.addEventListener("close", (closeEvent) => {
-            if ("yes" === confirmDialog.returnValue) {
-              this.#deleteObserver(closeButton, target.dataset.id);
-            }
-            closeEvent.stopPropagation();
-          }, { once: true });
-          confirmDialog.querySelector("label").innerText = `delete observer: ${target.dataset.id}?`
-          confirmDialog.showModal();
-        } else if ("cancel" === selectedAction) {
-          this.#hideDialog(closeButton);
-          // restore edited observed data after cancelling operation
-          const parentContainer = target.closest("div.observers-container");
-          const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
-          const index = Array.from(parentContainer.children)
-            .map((element) => element.querySelector("div.modal-button").innerText)
-            .findIndex((name) => name === this.#openedObserver.name);
-          const previousElement = index < 0 ? parentContainer.lastElementChild : parentContainer.children[index];
-          parentContainer.replaceChild(restoredElement, previousElement);
-          // re-bind listeners of the changed group
-          this.#bindListeners(this.#expandedGroup);
-          // clean previously opened observer data
-          this.#openedObserver = undefined;
-        } else {
-          CommonController.showToastError(`Unsupported accept button action: ${selectedAction}`);
-        }
-        clickEvent.stopPropagation();
-      });
+    modalCloseButtons.forEach((button) => this.#addCloseDialogListener(button));
   }
 
   #addOpenDialogListener(openButton) {
@@ -106,6 +70,45 @@ export class ObserversController {
       if (!this.#openedObserver.name) {
         this.#openedObserver = this.#expandedGroup;
       }
+    });
+  }
+
+  #addCloseDialogListener(closeButton) {
+    closeButton.addEventListener("click", (clickEvent) => {
+      const target = clickEvent.currentTarget;
+      const selectedAction = target.dataset.action;
+      if ("add" === selectedAction) {
+        this.#addObserver(closeButton, target.dataset.id);
+      } else if ("update" === selectedAction) {
+        this.#updateObserver(closeButton, target.dataset.id);
+      } else if ("delete" === selectedAction) {
+        const confirmDialog = document.querySelector("dialog.delete-observer-dialog");
+        confirmDialog.addEventListener("close", (closeEvent) => {
+          if ("yes" === confirmDialog.returnValue) {
+            this.#deleteObserver(closeButton, target.dataset.id);
+          }
+          closeEvent.stopPropagation();
+        }, { once: true });
+        confirmDialog.querySelector("label").innerText = `delete observer: ${target.dataset.id}?`
+        confirmDialog.showModal();
+      } else if ("cancel" === selectedAction) {
+        this.#hideDialog(closeButton);
+        // restore edited observed data after cancelling operation
+        const parentContainer = target.closest("div.observers-container");
+        const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
+        const index = Array.from(parentContainer.children)
+          .map((element) => element.querySelector("div.modal-button").innerText)
+          .findIndex((name) => name === this.#openedObserver.name);
+        const previousElement = index < 0 ? parentContainer.lastElementChild : parentContainer.children[index];
+        parentContainer.replaceChild(restoredElement, previousElement);
+        // re-bind listeners of the changed group
+        this.#bindListeners(this.#expandedGroup);
+        // clean previously opened observer data
+        this.#openedObserver = undefined;
+      } else {
+        CommonController.showToastError(`Unsupported accept button action: ${selectedAction}`);
+      }
+      clickEvent.stopPropagation();
     });
   }
 

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -5,6 +5,7 @@ import { ObserversView } from "./view-observer.js";
 export class ObserversController {
   #mediator = undefined;
   #expandedGroup = undefined;
+  #openedObserver = undefined;
 
   /**
    * Creates new observers controller
@@ -59,6 +60,8 @@ export class ObserversController {
         observerDialog.classList.remove("hidden");
         observerDialog.classList.add("init-reveal");
         event.stopPropagation();
+        // store initial HTML values of the selected observer
+        this.#openedObserver = ObserversView.fromHtml(target.parentNode);
       });
     });
     const modalCloseButtons = document.querySelectorAll(`${parentGroupSelector}div.modal-close-btn`);

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -85,6 +85,10 @@ export class ObserversController {
           confirmDialog.showModal();
         } else if ("cancel" === selectedAction) {
           this.#hideDialog(closeButton);
+          // restore edited observed data after cancelling operation
+          const restoredElement = CommonController.htmlToElement(ObserversView.toHtml(this.#openedObserver));
+          const parentContainer = target.closest("div.observers-container");
+          parentContainer.replaceChild(restoredElement, parentContainer.lastElementChild);
           // clean previously opened observer data
           this.#openedObserver = undefined;
         } else {

--- a/public/js/controller-observer.js
+++ b/public/js/controller-observer.js
@@ -40,6 +40,10 @@ export class ObserversController {
       this.#bindListeners();
       // since groups were reloaded then by definition observers were also reloaded
       this.emitEvent("observers-reloaded", undefined);
+    } else if ("group-restored" === eventType) {
+      this.#bindListeners(eventObject);
+      // since the group was restored then by definition observers were also restored
+      this.emitEvent("observers-reloaded", undefined);
     }
     return;
   }

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -105,6 +105,7 @@ export class ComponentsView {
     const selector = component !== undefined ? component.selector : "";
     const attribute = component !== undefined ? component.attribute : "";
     const auxiliary = component !== undefined ? component.auxiliary : "";
+    const auxButton = "" === auxiliary ? "Select image" : auxiliary;
     return `<div class="component-card">
               <h3 class="card-title">image config</h3>
               <div class="component-content">
@@ -119,7 +120,7 @@ export class ComponentsView {
                   </div>
                   <div class="widget">
                     <label class="component-image-label">auxiliary:</label>
-                    <input type="button" class="component-image-auxiliary" name="auxiliary" value="Select image" />
+                    <input type="button" class="component-image-auxiliary" name="auxiliary" value=${auxButton} />
                   </div>
                 </div>
                 <div class="component-toggle">

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -120,7 +120,7 @@ export class ComponentsView {
                   </div>
                   <div class="widget">
                     <label class="component-image-label">auxiliary:</label>
-                    <input type="button" class="component-image-auxiliary" name="auxiliary" value=${auxButton} />
+                    <input type="button" class="component-image-auxiliary" name="auxiliary" value="${auxButton}" />
                   </div>
                 </div>
                 <div class="component-toggle">


### PR DESCRIPTION
This patch fixes #22 
Opening/expanding observer/group store data and cancelling will restore them. No API calls needed.