### PR TITLE
Adjusting group titles depending on available width

### DIFF
--- a/public/css/columns.css
+++ b/public/css/columns.css
@@ -152,3 +152,7 @@
   background: transparent;
   transition: all 0.6s cubic-bezier(0.23, 1, 0.32, 1);
 }
+
+.group-title.vertical {
+  transform: rotate(-90deg);
+}

--- a/public/css/columns.css
+++ b/public/css/columns.css
@@ -148,7 +148,6 @@
   margin: 0;
   position: relative;
   z-index: 2;
-  width: 100%;
   font-size: 3.5vw;
   background: transparent;
   transition: all 0.6s cubic-bezier(0.23, 1, 0.32, 1);

--- a/public/css/columns.css
+++ b/public/css/columns.css
@@ -153,6 +153,14 @@
   transition: all 0.6s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
+.group-title.horizontal {
+  transform: rotate(0deg);
+}
+
+.group-title.diagonal {
+  transform: rotate(-60deg);
+}
+
 .group-title.vertical {
   transform: rotate(-90deg);
 }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -95,10 +95,11 @@ export class GroupsController {
    * Method used to initialize column dimensions (positions and size)
    */
   #initDimensions() {
+    // by default all column titles will be horizontal
+    let titleOrientationClass = "horizontal";
+    // set columns dimensions and adjust title rotate class if necessary
     this.#groupColumns.forEach((column) => {
-      // set column dimension
-      this.#setDimension(column)
-      // fit column title in available width (rotate if necessary)
+      this.#setDimension(column);
       const columnWidth = column.getBoundingClientRect().width;
       const columnTitle = column.querySelector("h2.group-title");
       const titleWidth = columnTitle.getBoundingClientRect().width;
@@ -106,9 +107,11 @@ export class GroupsController {
       if ("update" === column.dataset.action && columnWidth > 0 && columnWidth < titleWidth) {
         const diagonalRad = 60 * Math.PI / 180;
         const diagonalWidth = Math.abs(titleWidth * Math.cos(diagonalRad)) + Math.abs(titleHeight * Math.sin(diagonalRad));
-        columnTitle.classList.add((columnWidth < diagonalWidth) ? "vertical" : "diagonal");
+        titleOrientationClass = (columnWidth < diagonalWidth) ? "vertical" : "diagonal";
       }
     });
+    // apply column title orientation class to all titles
+    this.#groupColumns.forEach((column) => column.querySelector("h2.group-title").classList.add(titleOrientationClass));
   }
 
   /**

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -101,7 +101,7 @@ export class GroupsController {
       // compare column width against title width
       const columnWidth = column.getBoundingClientRect().width;
       const titleWidth = column.querySelector("h2.group-title").getBoundingClientRect().width;
-      if ("update" === column.dataset.action && columnWidth < titleWidth) {
+      if ("update" === column.dataset.action && columnWidth > 0 && columnWidth < titleWidth) {
         console.log("title is not fully visible");
       }
     });

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -98,10 +98,11 @@ export class GroupsController {
     this.#groupColumns.forEach((column) => {
       // set column dimension
       this.#setDimension(column)
-      // compare column width against title width
+      // fit column title in available width (rotate if necessary)
       const columnWidth = column.getBoundingClientRect().width;
       const columnTitle = column.querySelector("h2.group-title");
       const titleWidth = columnTitle.getBoundingClientRect().width;
+      const titleHeight = columnTitle.getBoundingClientRect().height;
       if ("update" === column.dataset.action && columnWidth > 0 && columnWidth < titleWidth) {
         columnTitle.classList.add("vertical");
       }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -386,6 +386,19 @@ export class GroupsController {
     column.parentNode.removeAttribute("style");
   }
 
+  #getColumnTitleOrientationClass(column) {
+    const columnWidth = column.getBoundingClientRect().width;
+    const columnTitle = column.querySelector("h2.group-title");
+    const titleWidth = columnTitle.getBoundingClientRect().width;
+    const titleHeight = columnTitle.getBoundingClientRect().height;
+    if ("update" === column.dataset.action && columnWidth > 0 && columnWidth < titleWidth) {
+      const diagonalRad = 60 * Math.PI / 180;
+      const diagonalWidth = Math.abs(titleWidth * Math.cos(diagonalRad)) + Math.abs(titleHeight * Math.sin(diagonalRad));
+      return (columnWidth < diagonalWidth) ? "vertical" : "diagonal";
+    }
+    return "horizontal";
+  }
+
   /**
    * Method used to receive an array of currently available colors
    * @returns an array with available colors (defined and currently generated)

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -95,7 +95,16 @@ export class GroupsController {
    * Method used to initialize column dimensions (positions and size)
    */
   #initDimensions() {
-    this.#groupColumns.forEach((column) => this.#setDimension(column));
+    this.#groupColumns.forEach((column) => {
+      // set column dimension
+      this.#setDimension(column)
+      // compare column width against title width
+      const columnWidth = column.getBoundingClientRect().width;
+      const titleWidth = column.querySelector("h2.group-title").getBoundingClientRect().width;
+      if ("update" === column.dataset.action && columnWidth < titleWidth) {
+        console.log("title is not fully visible");
+      }
+    });
   }
 
   /**

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -104,7 +104,9 @@ export class GroupsController {
       const titleWidth = columnTitle.getBoundingClientRect().width;
       const titleHeight = columnTitle.getBoundingClientRect().height;
       if ("update" === column.dataset.action && columnWidth > 0 && columnWidth < titleWidth) {
-        columnTitle.classList.add("vertical");
+        const diagonalRad = 60 * Math.PI / 180;
+        const diagonalWidth = Math.abs(titleWidth * Math.cos(diagonalRad)) + Math.abs(titleHeight * Math.sin(diagonalRad));
+        columnTitle.classList.add((columnWidth < diagonalWidth) ? "vertical" : "diagonal");
       }
     });
   }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -107,7 +107,7 @@ export class GroupsController {
       } else if ("horizontal" === titleOrientationClass) {
         titleOrientationClass = titleClass;
       } else {
-        titleOrientationClass = ("vertical" === titleClass) ? titleClass : "diagonal";
+        titleOrientationClass = "vertical" === titleClass ? titleClass : "diagonal";
       }
     });
     // apply column title orientation class to all titles
@@ -257,9 +257,8 @@ export class GroupsController {
     GroupsService.getGroups(parentUserId)
       .then((data) => {
         let html = "";
-        data[0].groups.forEach((group) => html += GroupsView.toHtml(group));
-        document.querySelector("section.group-columns")
-                .innerHTML = html + GroupsView.toHtml(data[0].user);
+        data[0].groups.forEach((group) => (html += GroupsView.toHtml(group)));
+        document.querySelector("section.group-columns").innerHTML = html + GroupsView.toHtml(data[0].user);
         this.#initController();
         // notify other controllers that groups were reloaded
         this.emitEvent("groups-reloaded", parentUserId);
@@ -392,9 +391,9 @@ export class GroupsController {
     const titleWidth = columnTitle.getBoundingClientRect().width;
     const titleHeight = columnTitle.getBoundingClientRect().height;
     if ("update" === column.dataset.action && columnWidth > 0 && columnWidth < titleWidth) {
-      const diagonalRad = 60 * Math.PI / 180;
+      const diagonalRad = (60 * Math.PI) / 180;
       const diagonalWidth = Math.abs(titleWidth * Math.cos(diagonalRad)) + Math.abs(titleHeight * Math.sin(diagonalRad));
-      return (columnWidth < diagonalWidth) ? "vertical" : "diagonal";
+      return columnWidth < diagonalWidth ? "vertical" : "diagonal";
     }
     return "horizontal";
   }
@@ -469,7 +468,7 @@ export class GroupsController {
       color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
     }
     if (6 !== color.length) {
-      CommonController.showToastError(`Cannot generate color. Invalid value: ${color}`)
+      CommonController.showToastError(`Cannot generate color. Invalid value: ${color}`);
       return "black";
     }
     const r = parseInt(color.slice(0, 2), 16);

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -100,14 +100,14 @@ export class GroupsController {
     // set columns dimensions and adjust title rotate class if necessary
     this.#groupColumns.forEach((column) => {
       this.#setDimension(column);
-      const columnWidth = column.getBoundingClientRect().width;
-      const columnTitle = column.querySelector("h2.group-title");
-      const titleWidth = columnTitle.getBoundingClientRect().width;
-      const titleHeight = columnTitle.getBoundingClientRect().height;
-      if ("update" === column.dataset.action && columnWidth > 0 && columnWidth < titleWidth) {
-        const diagonalRad = 60 * Math.PI / 180;
-        const diagonalWidth = Math.abs(titleWidth * Math.cos(diagonalRad)) + Math.abs(titleHeight * Math.sin(diagonalRad));
-        titleOrientationClass = (columnWidth < diagonalWidth) ? "vertical" : "diagonal";
+      const titleClass = this.#getColumnTitleOrientationClass(column);
+      // update the title orientation class variable for the least matching case
+      if ("vertical" === titleOrientationClass) {
+        return;
+      } else if ("horizontal" === titleOrientationClass) {
+        titleOrientationClass = titleClass;
+      } else {
+        titleOrientationClass = ("vertical" === titleClass) ? titleClass : "diagonal";
       }
     });
     // apply column title orientation class to all titles

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -100,9 +100,10 @@ export class GroupsController {
       this.#setDimension(column)
       // compare column width against title width
       const columnWidth = column.getBoundingClientRect().width;
-      const titleWidth = column.querySelector("h2.group-title").getBoundingClientRect().width;
+      const columnTitle = column.querySelector("h2.group-title");
+      const titleWidth = columnTitle.getBoundingClientRect().width;
       if ("update" === column.dataset.action && columnWidth > 0 && columnWidth < titleWidth) {
-        console.log("title is not fully visible");
+        columnTitle.classList.add("vertical");
       }
     });
   }

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -385,6 +385,11 @@ export class GroupsController {
     column.parentNode.removeAttribute("style");
   }
 
+  /**
+   * Method used to retrieve column title orientation class based on available width
+   * @param {Element} column The column for which we want to get title orientation class
+   * @returns group title orientation class ("horizontal", "diagonal", "vertical")
+   */
   #getColumnTitleOrientationClass(column) {
     const columnWidth = column.getBoundingClientRect().width;
     const columnTitle = column.querySelector("h2.group-title");

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -395,11 +395,15 @@ export class GroupsController {
     const columnTitle = column.querySelector("h2.group-title");
     const titleWidth = columnTitle.getBoundingClientRect().width;
     const titleHeight = columnTitle.getBoundingClientRect().height;
+    // check if we have enough space to fit the title in the specified column
     if ("update" === column.dataset.action && columnWidth > 0 && columnWidth < titleWidth) {
+      // no space to fit it horizontally, consider diagonal orientation (60 degrees tilt)
       const diagonalRad = (60 * Math.PI) / 180;
       const diagonalWidth = Math.abs(titleWidth * Math.cos(diagonalRad)) + Math.abs(titleHeight * Math.sin(diagonalRad));
+      // return diagonal if fits into column width, else use vertical (worst-case scenario)
       return columnWidth < diagonalWidth ? "vertical" : "diagonal";
     }
+    // we have enough space to fit title horizontally (best-case scenario)
     return "horizontal";
   }
 


### PR DESCRIPTION
This patch fixes #25 
When at least one title does not fit all are adjusted: first diagonal (60deg) and then vertical.