### PR TITLE
Load initial configuration from DB after logging

### DIFF
--- a/public/index.handlebars
+++ b/public/index.handlebars
@@ -1,10 +1,8 @@
 <section class="group-columns hide">
-  {{#each content}}
-    {{#each groups}}
-      {{> group-edit group=this }}
-    {{/each}}
-    {{> group-add userId=user }}
+  {{#each content.groups}}
+    {{> group-edit group=this }}
   {{/each}}
+  {{> group-add userId=user }}
 </section>
 <section class="group-status show">
   <div class="group-loader loading"></div>

--- a/public/js/controller-group.js
+++ b/public/js/controller-group.js
@@ -486,10 +486,6 @@ export class GroupsController {
    */
   #storeGroupData(groupTarget) {
     this.#groupExpanded = GroupsView.fromHtml(groupTarget);
-    // if stored group does not have a name then it's a new one = we have to remember the user ID
-    if (!this.#groupExpanded.name) {
-      this.#groupExpanded = 0;
-    }
   }
 
   /**
@@ -508,7 +504,8 @@ export class GroupsController {
     const childIndex = Array.from(parentContainer.children)
       .map((element) => element.querySelector("h2.group-title").innerText)
       .findIndex((name) => name === this.#groupExpanded.name);
-    const restoredElement = CommonController.htmlToElement(GroupsView.toHtml(this.#groupExpanded));
+    const restoredObject = childIndex < 0 ? undefined : this.#groupExpanded;
+    const restoredElement = CommonController.htmlToElement(GroupsView.toHtml(restoredObject));
     const previousElement = childIndex < 0 ? parentContainer.lastElementChild : parentContainer.children[childIndex];
     // restore child elements to keep group collapse animation continuity
     const restoreChildren = ["div.group-root-data", "div.group-observers", "div.group-buttons"];

--- a/src/routes/api/config-router.js
+++ b/src/routes/api/config-router.js
@@ -364,11 +364,11 @@ export class ConfigRouter {
       // perform update operation
       const updateStatus = update(configContent);
       if (updateStatus.success) {
-        configContent.save();
+        await configContent.save();
         // if we've created a new blank configuration then we must link it in the user
         if (user.config == null) {
           user.config = configContent._id;
-          user.save();
+          await user.save();
         }
       }
       return { status: updateStatus.success ? 200 : 400, message: updateStatus.message };

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -48,7 +48,7 @@ export class ViewRouter {
       response.render("index", {
         title: "scraper configuration",
         user: request.user.name,
-        content: scrapConfig,
+        content: scrapConfig.toJSON(),
         categories: this.#getSupportedCategories(),
         currencies: this.#getSupportedCurrencies(),
       });

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -41,8 +41,10 @@ export class ViewRouter {
    * @param {Object} router The router object with GET method routes defined
    */
   #createGetRoutes(router) {
-    router.get("/", AccessChecker.canViewContent, (request, response) => {
-      const scrapConfig = JSON.parse(fs.readFileSync(this.#configFilePath)).map((item) => new ScrapConfig(item));
+    router.get("/", AccessChecker.canViewContent, async (request, response) => {
+      const scrapConfig = request.user.config == null
+        ? await ScrapConfig.getDatabaseModel().create({ user: request.user._id })
+        : await ScrapConfig.getDatabaseModel().findById(request.user.config);
       response.render("index", {
         title: "scraper configuration",
         user: request.user.name,

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -110,6 +110,11 @@ export class ViewRouter {
     return "PLN|GBP|USD|EUR|CHF|CZK|DKK|CNY|JPY|INR|AUD|CAD";
   }
 
+  /**
+   * Method used to retrieve scraper configuration for specified user
+   * @param {Object} user The ID of the user which configuration we want to retrieve
+   * @returns The scraper configuration of the specified user
+   */
   async #getScrapConfigForUser(user) {
     if (user.config == null) {
       // user has no config - create and link it

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -4,7 +4,6 @@ import { ScrapUser } from "../../model/scrap-user.js";
 
 import express from "express";
 import bcrypt from "bcrypt";
-import fs from "fs";
 import { MongooseError } from "mongoose";
 import { Strategy } from "passport-local";
 


### PR DESCRIPTION
This patch fixes #54 
Now after logging in the scraper configuration is correctly presented to the user. Also switching between user will correctly update the UI.