### PR TITLE
Automatically update page year

### DIFF
--- a/public/layouts/main.handlebars
+++ b/public/layouts/main.handlebars
@@ -48,7 +48,7 @@
       </div>
       {{!-- page footer --}}
       <footer id="main-footer">
-        <h3>developed with 💚 pnk @ 2023</h3>
+        <h3>developed with 💚 pnk @ {{year}}</h3>
         <div id="footer-links">
           {{#if (eq type "status")}}
           <div id="status-preview" class="expanded">


### PR DESCRIPTION
This patch updated the main handlebars template to use year helper and update the license year in all views