### PR TITLE
Create and use JWT after successful login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,11 @@
         "express-handlebars": "^8.0.1",
         "express-session": "^1.18.0",
         "handlebars-helpers": "^0.10.0",
+        "jsonwebtoken": "^9.0.2",
         "moment": "^2.30.1",
         "mongoose": "^8.6.3",
         "passport": "^0.7.0",
+        "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
         "puppeteer": "^23.1.0",
         "web-scraper": "file:"
@@ -2404,6 +2406,11 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3230,6 +3237,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -5991,6 +6006,51 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -6057,6 +6117,41 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA=="
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -7135,6 +7230,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==",
+      "dependencies": {
+        "jsonwebtoken": "^9.0.0",
+        "passport-strategy": "^1.0.0"
       }
     },
     "node_modules/passport-local": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
     "express-handlebars": "^8.0.1",
     "express-session": "^1.18.0",
     "handlebars-helpers": "^0.10.0",
+    "jsonwebtoken": "^9.0.2",
     "moment": "^2.30.1",
     "mongoose": "^8.6.3",
     "passport": "^0.7.0",
+    "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
     "puppeteer": "^23.1.0",
     "web-scraper": "file:"

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -10,9 +10,10 @@ main();
  * Method used to initialize script
  */
 function main() {
-  // initialize scrap config only when main index page is opened
+  // initialize scrap config and receive JWT only when main index page is opened and if needed
   if (isGroupsInitializationNeeded()) {
     initializeScraperConfig();
+    initializeJWT();
   }
   // start current status controller and monitor components
   const statusController = new StatusController();
@@ -43,6 +44,15 @@ function initializeScraperConfig() {
   mediator.register(componentsController);
   mediator.register(observersController);
   mediator.register(groupsController);
+}
+
+async function initializeJWT() {
+  const url = `/auth/token`;
+  const response = await fetch(url, { method: "GET" });
+  if (response.status === 200) {
+    const jwt = await response.json();
+    localStorage.setItem("JWT", jwt.token);
+  }
 }
 
 /**

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -18,6 +18,14 @@ function main() {
   // start current status controller and monitor components
   const statusController = new StatusController();
   statusController.start();
+  // add user logout button handler cleaning JWT
+  const logoutButton = document.getElementById("user-logout");
+  if (logoutButton) {
+    logoutButton.addEventListener("submit", () => {
+      localStorage.removeItem("JWT");
+      return true;
+    });
+  }
 }
 
 /**

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -55,6 +55,9 @@ function initializeScraperConfig() {
 }
 
 async function initializeJWT() {
+  if (localStorage.getItem("JWT")) {
+    return;
+  }
   const url = `/auth/token`;
   const response = await fetch(url, { method: "GET" });
   if (response.status === 200) {

--- a/public/js/service-common.js
+++ b/public/js/service-common.js
@@ -29,7 +29,10 @@ export class CommonService {
   static createRequestOptions(requestMethod, requestBody = undefined) {
     return {
       method: requestMethod,
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("JWT")}`,
+      },
       body: requestBody,
     };
   }

--- a/public/js/service-common.js
+++ b/public/js/service-common.js
@@ -30,7 +30,7 @@ export class CommonService {
     return {
       method: requestMethod,
       headers: {
-        "Content-Type": contentType,
+        ...(contentType && { "Content-Type": contentType }),
         Authorization: `Bearer ${localStorage.getItem("JWT")}`,
       },
       body: requestBody,

--- a/public/js/service-common.js
+++ b/public/js/service-common.js
@@ -26,11 +26,11 @@ export class CommonService {
    * @param {Object} requestBody The HTTP body of the request
    * @returns request options object
    */
-  static createRequestOptions(requestMethod, requestBody = undefined) {
+  static createRequestOptions(requestMethod, requestBody = undefined, contentType = "application/json") {
     return {
       method: requestMethod,
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": contentType,
         Authorization: `Bearer ${localStorage.getItem("JWT")}`,
       },
       body: requestBody,

--- a/public/js/service-common.js
+++ b/public/js/service-common.js
@@ -1,4 +1,6 @@
 export class CommonService {
+  static TYPE_JSON = "application/json";
+
   /**
    * Method used to return error string from the input error response object
    * @param {Object} errorResponse The object containing error details
@@ -26,7 +28,7 @@ export class CommonService {
    * @param {Object} requestBody The HTTP body of the request
    * @returns request options object
    */
-  static createRequestOptions(requestMethod, requestBody = undefined, contentType = "application/json") {
+  static createRequestOptions(requestMethod, requestBody = undefined, contentType = undefined) {
     return {
       method: requestMethod,
       headers: {

--- a/public/js/service-common.js
+++ b/public/js/service-common.js
@@ -26,6 +26,7 @@ export class CommonService {
    * Method used to create request options
    * @param {String} requestMethod The HTTP method of the request
    * @param {Object} requestBody The HTTP body of the request
+   * @param {String} contentType The content type of the request
    * @returns request options object
    */
   static createRequestOptions(requestMethod, requestBody = undefined, contentType = undefined) {

--- a/public/js/service-component.js
+++ b/public/js/service-component.js
@@ -10,7 +10,8 @@ export class ComponentService {
     const url = `/image`;
     const requestBody = new FormData();
     requestBody.append(inputFile.getAttribute("name"), inputFile.files[0]);
-    const response = await fetch(url, CommonService.createRequestOptions("POST", requestBody, ""));
+    const requestOptions = CommonService.createRequestOptions("POST", requestBody, "");
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }

--- a/public/js/service-component.js
+++ b/public/js/service-component.js
@@ -10,7 +10,7 @@ export class ComponentService {
     const url = `/image`;
     const requestBody = new FormData();
     requestBody.append(inputFile.getAttribute("name"), inputFile.files[0]);
-    const response = await fetch(url, CommonService.createRequestOptions("POST", requestBody, "multipart/form-data"));
+    const response = await fetch(url, CommonService.createRequestOptions("POST", requestBody, ""));
     if (response.status === 200) {
       return response.json();
     }

--- a/public/js/service-component.js
+++ b/public/js/service-component.js
@@ -10,7 +10,7 @@ export class ComponentService {
     const url = `/image`;
     const requestBody = new FormData();
     requestBody.append(inputFile.getAttribute("name"), inputFile.files[0]);
-    const response = await fetch(url, { method: "POST", body: requestBody });
+    const response = await fetch(url, CommonService.createRequestOptions("POST", requestBody, "multipart/form-data"));
     if (response.status === 200) {
       return response.json();
     }

--- a/public/js/service-component.js
+++ b/public/js/service-component.js
@@ -10,8 +10,8 @@ export class ComponentService {
     const url = `/image`;
     const requestBody = new FormData();
     requestBody.append(inputFile.getAttribute("name"), inputFile.files[0]);
-    const requestOptions = CommonService.createRequestOptions("POST", requestBody, "");
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("POST", requestBody);
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }

--- a/public/js/service-component.js
+++ b/public/js/service-component.js
@@ -10,6 +10,8 @@ export class ComponentService {
     const url = `/image`;
     const requestBody = new FormData();
     requestBody.append(inputFile.getAttribute("name"), inputFile.files[0]);
+    // for images (generally: multipart/*) we deliberately do NOT define the content type
+    // thus the browser will detect and set it automatically with correct boundary value
     const requestOpts = CommonService.createRequestOptions("POST", requestBody);
     const response = await fetch(url, requestOpts);
     if (response.status === 200) {

--- a/public/js/service-group.js
+++ b/public/js/service-group.js
@@ -10,8 +10,8 @@ export class GroupsService {
     const url = `api/v1/config/groups`;
     const expandedGroup = document.querySelector("article.group-column.expanded");
     const requestBody = JSON.stringify(GroupsView.fromHtml(expandedGroup));
-    const requestOptions = CommonService.createRequestOptions("POST", requestBody);
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("POST", requestBody, CommonService.TYPE_JSON);
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }
@@ -26,8 +26,8 @@ export class GroupsService {
    */
   static async getGroups() {
     const url = `api/v1/config`;
-    const requestOptions = CommonService.createRequestOptions("GET");
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("GET");
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }
@@ -45,8 +45,8 @@ export class GroupsService {
     const url = `api/v1/config/groups?name=${encodeURIComponent(groupId)}`;
     const expandedGroup = document.querySelector("article.group-column.expanded");
     const requestBody = JSON.stringify(GroupsView.fromHtml(expandedGroup));
-    const requestOptions = CommonService.createRequestOptions("PUT", requestBody);
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("PUT", requestBody, CommonService.TYPE_JSON);
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }
@@ -62,8 +62,8 @@ export class GroupsService {
    */
   static async deleteGroup(groupId) {
     const url = `api/v1/config/groups?name=${encodeURIComponent(groupId)}`;
-    const requestOptions = CommonService.createRequestOptions("DELETE");
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("DELETE");
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }

--- a/public/js/service-group.js
+++ b/public/js/service-group.js
@@ -10,7 +10,8 @@ export class GroupsService {
     const url = `api/v1/config/groups`;
     const expandedGroup = document.querySelector("article.group-column.expanded");
     const requestBody = JSON.stringify(GroupsView.fromHtml(expandedGroup));
-    const response = await fetch(url, CommonService.createRequestOptions("POST", requestBody));
+    const requestOptions = CommonService.createRequestOptions("POST", requestBody);
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }
@@ -25,7 +26,8 @@ export class GroupsService {
    */
   static async getGroups() {
     const url = `api/v1/config`;
-    const response = await fetch(url, CommonService.createRequestOptions("GET"));
+    const requestOptions = CommonService.createRequestOptions("GET");
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }
@@ -43,7 +45,8 @@ export class GroupsService {
     const url = `api/v1/config/groups?name=${encodeURIComponent(groupId)}`;
     const expandedGroup = document.querySelector("article.group-column.expanded");
     const requestBody = JSON.stringify(GroupsView.fromHtml(expandedGroup));
-    const response = await fetch(url, CommonService.createRequestOptions("PUT", requestBody));
+    const requestOptions = CommonService.createRequestOptions("PUT", requestBody);
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }
@@ -59,7 +62,8 @@ export class GroupsService {
    */
   static async deleteGroup(groupId) {
     const url = `api/v1/config/groups?name=${encodeURIComponent(groupId)}`;
-    const response = await fetch(url, CommonService.createRequestOptions("DELETE"));
+    const requestOptions = CommonService.createRequestOptions("DELETE");
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }

--- a/public/js/service-observer.js
+++ b/public/js/service-observer.js
@@ -11,8 +11,8 @@ export class ObserversService {
     const url = `api/v1/config/groups/observers?parent=${encodeURIComponent(parentId)}`;
     const openedObserver = document.querySelector("div.modal-dialog.init-reveal:not(.hidden)");
     const requestBody = JSON.stringify(ObserversView.fromHtml(openedObserver));
-    const requestOptions = CommonService.createRequestOptions("POST", requestBody);
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("POST", requestBody, CommonService.TYPE_JSON);
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }
@@ -28,8 +28,8 @@ export class ObserversService {
    */
   static async getObservers(parentId) {
     const url = `api/v1/config/groups?name=${encodeURIComponent(parentId)}`;
-    const requestOptions = CommonService.createRequestOptions("GET");
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("GET");
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }
@@ -47,8 +47,8 @@ export class ObserversService {
     const url = `api/v1/config/groups/observers?name=${encodeURIComponent(observerId)}`;
     const openedObserver = document.querySelector("div.modal-dialog.init-reveal:not(.hidden)");
     const requestBody = JSON.stringify(ObserversView.fromHtml(openedObserver));
-    const requestOptions = CommonService.createRequestOptions("PUT", requestBody);
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("PUT", requestBody, CommonService.TYPE_JSON);
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }
@@ -64,8 +64,8 @@ export class ObserversService {
    */
   static async deleteObserver(observerId) {
     const url = `api/v1/config/groups/observers?name=${encodeURIComponent(observerId)}`;
-    const requestOptions = CommonService.createRequestOptions("DELETE");
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("DELETE");
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }

--- a/public/js/service-observer.js
+++ b/public/js/service-observer.js
@@ -11,7 +11,8 @@ export class ObserversService {
     const url = `api/v1/config/groups/observers?parent=${encodeURIComponent(parentId)}`;
     const openedObserver = document.querySelector("div.modal-dialog.init-reveal:not(.hidden)");
     const requestBody = JSON.stringify(ObserversView.fromHtml(openedObserver));
-    const response = await fetch(url, CommonService.createRequestOptions("POST", requestBody));
+    const requestOptions = CommonService.createRequestOptions("POST", requestBody);
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }
@@ -27,7 +28,8 @@ export class ObserversService {
    */
   static async getObservers(parentId) {
     const url = `api/v1/config/groups?name=${encodeURIComponent(parentId)}`;
-    const response = await fetch(url, CommonService.createRequestOptions("GET"));
+    const requestOptions = CommonService.createRequestOptions("GET");
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }
@@ -45,7 +47,8 @@ export class ObserversService {
     const url = `api/v1/config/groups/observers?name=${encodeURIComponent(observerId)}`;
     const openedObserver = document.querySelector("div.modal-dialog.init-reveal:not(.hidden)");
     const requestBody = JSON.stringify(ObserversView.fromHtml(openedObserver));
-    const response = await fetch(url, CommonService.createRequestOptions("PUT", requestBody));
+    const requestOptions = CommonService.createRequestOptions("PUT", requestBody);
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }
@@ -61,7 +64,8 @@ export class ObserversService {
    */
   static async deleteObserver(observerId) {
     const url = `api/v1/config/groups/observers?name=${encodeURIComponent(observerId)}`;
-    const response = await fetch(url, CommonService.createRequestOptions("DELETE"));
+    const requestOptions = CommonService.createRequestOptions("DELETE");
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }

--- a/public/js/service-status.js
+++ b/public/js/service-status.js
@@ -10,7 +10,8 @@ export class StatusService {
   static async getStatus(componentName = undefined, withHistory = false) {
     const componentUrl = componentName ? `name=${componentName}&` : "";
     const url = `/api/v1/status?${componentUrl}history=${withHistory}`;
-    const response = await fetch(url, CommonService.createRequestOptions("GET"));
+    const requestOptions = CommonService.createRequestOptions("GET");
+    const response = await fetch(url, requestOptions);
     if (response.status === 200) {
       return response.json();
     }

--- a/public/js/service-status.js
+++ b/public/js/service-status.js
@@ -10,8 +10,8 @@ export class StatusService {
   static async getStatus(componentName = undefined, withHistory = false) {
     const componentUrl = componentName ? `name=${componentName}&` : "";
     const url = `/api/v1/status?${componentUrl}history=${withHistory}`;
-    const requestOptions = CommonService.createRequestOptions("GET");
-    const response = await fetch(url, requestOptions);
+    const requestOpts = CommonService.createRequestOptions("GET");
+    const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();
     }

--- a/public/layouts/main.handlebars
+++ b/public/layouts/main.handlebars
@@ -38,7 +38,7 @@
           {{#if user}}
           <div class="user-management">
             <h5>user: {{user}}</h5>
-            <form action="/auth/logout" method="POST">
+            <form id="user-logout" action="/auth/logout" method="POST">
               <button type="submit" id="user-logout"><i class="fa fa-sign-out"></i>logout</button>
             </form>
           </div>

--- a/src/components/web-server.js
+++ b/src/components/web-server.js
@@ -88,6 +88,8 @@ export class WebServer {
     server.use(passport.initialize());
     server.use(passport.session());
     server.use(cors(this.#getCorsConfiguration()))
+    // configure passport and add it to local variable
+    server.locals.passport = passport;
     // setup web server routes
     const routes = new Map([
       ["/", new ViewRouter(this.#setupConfig.usersDataConfig.path)],

--- a/src/middleware/access-checker.js
+++ b/src/middleware/access-checker.js
@@ -25,6 +25,7 @@ export class AccessChecker {
     }
     const jwtOpts = {
       session: false,
+      failureRedirect: "/auth/login"
     };
     return request.app.locals.passport.authenticate("jwt", jwtOpts)(request, response, next);
   }
@@ -41,6 +42,7 @@ export class AccessChecker {
     }
     const jwtOpts = {
       session: false,
+      failureRedirect: "/"
     };
     return request.app.locals.passport.authenticate("jwt", jwtOpts)(request, response, next);
   }

--- a/src/middleware/access-checker.js
+++ b/src/middleware/access-checker.js
@@ -9,7 +9,7 @@ export class AccessChecker {
     if (request.isAuthenticated()) {
       return next();
     }
-    response.status(401).json("Not authenticated");
+    response.status(401).json("Unauthorized");
   }
 
   /**

--- a/src/middleware/access-checker.js
+++ b/src/middleware/access-checker.js
@@ -6,6 +6,9 @@ export class AccessChecker {
    * @param {Function} next The next middleware function in the cycle
    */
   static canReceiveData(request, response, next) {
+    if (request.app.locals.passport.authenticate("jwt", {session: false})) {
+      return next();
+    }
     if (request.isAuthenticated()) {
       return next();
     }
@@ -19,6 +22,9 @@ export class AccessChecker {
    * @param {Function} next The next middleware function in the cycle
    */
   static canViewContent(request, response, next) {
+    if (request.app.locals.passport.authenticate("jwt", {session: false})) {
+      return next();
+    }
     if (request.isAuthenticated()) {
       return next();
     }
@@ -32,6 +38,9 @@ export class AccessChecker {
    * @param {Function} next The next middleware function in the cycle
    */
   static canViewSessionUser(request, response, next) {
+    if (!request.app.locals.passport.authenticate("jwt", {session: false})) {
+      return next();
+    }
     if (!request.isAuthenticated()) {
       return next();
     }

--- a/src/middleware/access-checker.js
+++ b/src/middleware/access-checker.js
@@ -23,10 +23,7 @@ export class AccessChecker {
     if (request.isAuthenticated()) {
       return next();
     }
-    const jwtOpts = {
-      session: false,
-      failureRedirect: "/auth/login"
-    };
+    const jwtOpts = { session: false, failureRedirect: "/auth/login" };
     return request.app.locals.passport.authenticate("jwt", jwtOpts)(request, response, next);
   }
 
@@ -40,10 +37,7 @@ export class AccessChecker {
     if (!request.isAuthenticated()) {
       return next();
     }
-    const jwtOpts = {
-      session: false,
-      failureRedirect: "/"
-    };
+    const jwtOpts = { session: false, failureRedirect: "/" };
     return request.app.locals.passport.authenticate("jwt", jwtOpts)(request, response, next);
   }
 }

--- a/src/middleware/access-checker.js
+++ b/src/middleware/access-checker.js
@@ -6,13 +6,11 @@ export class AccessChecker {
    * @param {Function} next The next middleware function in the cycle
    */
   static canReceiveData(request, response, next) {
-    if (request.app.locals.passport.authenticate("jwt", {session: false})) {
-      return next();
-    }
     if (request.isAuthenticated()) {
       return next();
     }
-    response.status(401).json("Unauthorized");
+    const jwtOpts = { session: false };
+    return request.app.locals.passport.authenticate("jwt", jwtOpts)(request, response, next);
   }
 
   /**
@@ -22,13 +20,13 @@ export class AccessChecker {
    * @param {Function} next The next middleware function in the cycle
    */
   static canViewContent(request, response, next) {
-    if (request.app.locals.passport.authenticate("jwt", {session: false})) {
-      return next();
-    }
     if (request.isAuthenticated()) {
       return next();
     }
-    response.redirect("/auth/login");
+    const jwtOpts = {
+      session: false,
+    };
+    return request.app.locals.passport.authenticate("jwt", jwtOpts)(request, response, next);
   }
 
   /**
@@ -38,12 +36,12 @@ export class AccessChecker {
    * @param {Function} next The next middleware function in the cycle
    */
   static canViewSessionUser(request, response, next) {
-    if (!request.app.locals.passport.authenticate("jwt", {session: false})) {
-      return next();
-    }
     if (!request.isAuthenticated()) {
       return next();
     }
-    response.redirect("/");
+    const jwtOpts = {
+      session: false,
+    };
+    return request.app.locals.passport.authenticate("jwt", jwtOpts)(request, response, next);
   }
 }

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -98,7 +98,7 @@ export class AuthRouter {
           return res.json({ userJson, token });
         });
       })(req, res);
-    }
+    };
     router.post("/login", AccessChecker.canViewSessionUser, loginCallback);
     // user content endpoints (log-out)
     const logoutCallback = (request, response, next) => {

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -56,8 +56,8 @@ export class AuthRouter {
       })
     );
     router.get("/token", AccessChecker.canViewContent, (request, response) => {
-      request.session.jwt = jwt.sign(request.user.toJSON(), "your_jwt_secret");
-      return response.redirect("/");
+      const token = jwt.sign(request.user.toJSON(), "your_jwt_secret");
+      return response.status(200).json({token});
     });
   }
 

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -57,7 +57,7 @@ export class AuthRouter {
     );
     router.get("/token", AccessChecker.canViewContent, (request, response) => {
       request.session.jwt = jwt.sign(request.user.toJSON(), "your_jwt_secret");
-      console.log(request.session.jwt);
+      return response.redirect("/");
     });
   }
 

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -69,13 +69,14 @@ export class AuthRouter {
       session: false,
     });
     router.post("/register", AccessChecker.canViewSessionUser, registerCallback);
-    const loginCallback = this.#passport.authenticate("local-login", {
+    const loginOptions = {
       successRedirect: "/",
       failureRedirect: "/auth/login",
       failureFlash: true,
-    });
+    };
+    const loginCallback = this.#passport.authenticate("local-login", loginOptions);
     const loginCallbackJwt = (req, res, next) => {
-      this.#passport.authenticate("local-login", {session: false}, (err, user, info) => {
+      this.#passport.authenticate("local-login", loginOptions, (err, user, info) => {
         const userJson = user.toJSON();
         if (err || !userJson) {
           return res.status(400).json({
@@ -83,7 +84,7 @@ export class AuthRouter {
             user: userJson,
           });
         }
-        req.login(userJson, {session: false}, (err) => {
+        req.login(userJson, loginOptions, (err) => {
           if (err) {
             res.send(err);
           }

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -58,7 +58,7 @@ export class AuthRouter {
     );
     router.get("/token", AccessChecker.canViewContent, (request, response) => {
       const token = jwt.sign(request.user.toJSON(), process.env.JWT_SECRET);
-      return response.status(200).json({token});
+      return response.status(200).json({ token });
     });
   }
 

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -75,7 +75,7 @@ export class AuthRouter {
     });
     router.post("/register", AccessChecker.canViewSessionUser, registerCallback);
     const loginOptions = {
-      successRedirect: "/auth/token",
+      successRedirect: "/",
       failureRedirect: "/auth/login",
       failureFlash: true,
     };

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -74,6 +74,25 @@ export class AuthRouter {
       failureRedirect: "/auth/login",
       failureFlash: true,
     });
+    const loginCallbackJwt = (req, res, next) => {
+      this.#passport.authenticate("local-login", {session: false}, (err, user, info) => {
+        const userJson = user.toJSON();
+        if (err || !userJson) {
+          return res.status(400).json({
+            message: "Something is not right",
+            user: userJson,
+          });
+        }
+        req.login(userJson, {session: false}, (err) => {
+          if (err) {
+            res.send(err);
+          }
+          // generate a signed son web token with the contents of user object and return it in the response
+          const token = jwt.sign(userJson, "your_jwt_secret");
+          return res.json({ userJson, token });
+        });
+      })(req, res);
+    }
     router.post("/login", AccessChecker.canViewSessionUser, loginCallback);
     // user content endpoints (log-out)
     const logoutCallback = (request, response, next) => {

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -56,7 +56,7 @@ export class AuthRouter {
       })
     );
     router.get("/token", AccessChecker.canViewContent, (request, response) => {
-      const token = jwt.sign(request.user.toJSON(), "your_jwt_secret");
+      const token = jwt.sign(request.user.toJSON(), process.env.JWT_SECRET);
       return response.status(200).json({token});
     });
   }
@@ -94,7 +94,7 @@ export class AuthRouter {
             res.send(err);
           }
           // generate a signed son web token with the contents of user object and return it in the response
-          const token = jwt.sign(userJson, "your_jwt_secret");
+          const token = jwt.sign(userJson, process.env.JWT_SECRET);
           return res.json({ userJson, token });
         });
       })(req, res);

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -120,7 +120,7 @@ export class AuthRouter {
     };
     const verify = async (jwtPayload, done) => {
       try {
-        const user = await ScrapUser.getDatabaseModel().findById(jwtPayload.id);
+        const user = await ScrapUser.getDatabaseModel().findById(jwtPayload._id);
         if (user) {
           return done(null, user);
         }

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -3,6 +3,7 @@ import { ComponentType } from "../../../config/app-types.js";
 import { ScrapConfig } from "../../model/scrap-config.js";
 import { ScrapUser } from "../../model/scrap-user.js";
 
+import jwt from "jsonwebtoken";
 import express from "express";
 import bcrypt from "bcrypt";
 import { MongooseError } from "mongoose";

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -113,6 +113,10 @@ export class AuthRouter {
     });
   }
 
+  /**
+   * Method used to configurate user JWT login strategy
+   * @param {Object} passport The login auth and stategy object
+   */
   #configJwtStategy(passport) {
     const options = {
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -133,7 +137,7 @@ export class AuthRouter {
   }
 
   /**
-   * Method used to configurate user login strategy (currently only local login is possible)
+   * Method used to configurate user local login strategy
    * @param {Object} passport The login auth and stategy object
    */
   #configLoginStategy(passport) {
@@ -178,8 +182,8 @@ export class AuthRouter {
   }
 
   /**
-   * Method used to configurate user register strategy
-   * @param {Object} passport The login auth and stategy object
+   * Method used to configurate user local register strategy
+   * @param {Object} passport The register auth and stategy object
    */
   #configRegisterStategy(passport) {
     const options = { usernameField: "email", passwordField: "password", passReqToCallback: true };

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -60,9 +60,6 @@ export class AuthRouter {
       const token = jwt.sign(request.user.toJSON(), process.env.JWT_SECRET);
       return response.status(200).json({ token });
     });
-    router.get("/test", this.#passport.authenticate("jwt", {session: false}), (request, response) => {
-      return response.status(200).json({ msg: "You are successfully authenticated to this route!" });
-    });
   }
 
   /**

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -8,7 +8,7 @@ import express from "express";
 import bcrypt from "bcrypt";
 import { MongooseError } from "mongoose";
 import { Strategy } from "passport-local";
-import { ExtractJwt, JwtStrategy } from "passport-jwt";
+import { ExtractJwt, Strategy } from "passport-jwt";
 
 export class AuthRouter {
   static #ENCRYPT_SALT = 10;
@@ -116,10 +116,17 @@ export class AuthRouter {
       secretOrKey: process.env.JWT_SECRET,
     };
     const verify = async (jwtPayload, done) => {
-       const user = await ScrapUser.getDatabaseModel().findById(jwtPayload.id);
-       return done(null, user);
+      try {
+        const user = await ScrapUser.getDatabaseModel().findById(jwtPayload.id);
+        if (user) {
+          return done(null, user);
+        }
+        return done(null, false, { message: "Incorrect token." });
+      } catch (error) {
+        return done(null, false, { message: error.message });
+      }
     };
-    passport.use("jwt", new JwtStrategy(options, verify));
+    passport.use("jwt", new Strategy(options, verify));
   }
 
   /**

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -7,8 +7,8 @@ import jwt from "jsonwebtoken";
 import express from "express";
 import bcrypt from "bcrypt";
 import { MongooseError } from "mongoose";
-import { Strategy } from "passport-local";
-import { ExtractJwt, Strategy } from "passport-jwt";
+import { Strategy as LocalStategy } from "passport-local";
+import { ExtractJwt, Strategy as JwtStrategy } from "passport-jwt";
 
 export class AuthRouter {
   static #ENCRYPT_SALT = 10;
@@ -126,7 +126,7 @@ export class AuthRouter {
         return done(null, false, { message: error.message });
       }
     };
-    passport.use("jwt", new Strategy(options, verify));
+    passport.use("jwt", new JwtStrategy(options, verify));
   }
 
   /**
@@ -171,7 +171,7 @@ export class AuthRouter {
         return done(null, false, { message: message });
       }
     };
-    passport.use("local-login", new Strategy(options, verify));
+    passport.use("local-login", new LocalStategy(options, verify));
   }
 
   /**
@@ -216,6 +216,6 @@ export class AuthRouter {
         return done(null, false, { message: message });
       }
     };
-    passport.use("local-register", new Strategy(options, verify));
+    passport.use("local-register", new LocalStategy(options, verify));
   }
 }

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -55,6 +55,10 @@ export class AuthRouter {
         type: "login",
       })
     );
+    router.get("/token", AccessChecker.canViewContent, (request, response) => {
+      request.session.jwt = jwt.sign(request.user.toJSON(), "your_jwt_secret");
+      console.log(request.session.jwt);
+    });
   }
 
   /**
@@ -71,7 +75,7 @@ export class AuthRouter {
     });
     router.post("/register", AccessChecker.canViewSessionUser, registerCallback);
     const loginOptions = {
-      successRedirect: "/",
+      successRedirect: "/auth/token",
       failureRedirect: "/auth/login",
       failureFlash: true,
     };

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -60,6 +60,9 @@ export class AuthRouter {
       const token = jwt.sign(request.user.toJSON(), process.env.JWT_SECRET);
       return response.status(200).json({ token });
     });
+    router.get("/test", this.#passport.authenticate("jwt", {session: false}), (request, response) => {
+      return response.status(200).json({ msg: "You are successfully authenticated to this route!" });
+    });
   }
 
   /**

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -74,31 +74,11 @@ export class AuthRouter {
       session: false,
     });
     router.post("/register", AccessChecker.canViewSessionUser, registerCallback);
-    const loginOptions = {
+    const loginCallback = this.#passport.authenticate("local-login", {
       successRedirect: "/",
       failureRedirect: "/auth/login",
       failureFlash: true,
-    };
-    const loginCallback = this.#passport.authenticate("local-login", loginOptions);
-    const loginCallbackJwt = (req, res, next) => {
-      this.#passport.authenticate("local-login", loginOptions, (err, user, info) => {
-        const userJson = user.toJSON();
-        if (err || !userJson) {
-          return res.status(400).json({
-            message: "Something is not right",
-            user: userJson,
-          });
-        }
-        req.login(userJson, loginOptions, (err) => {
-          if (err) {
-            res.send(err);
-          }
-          // generate a signed son web token with the contents of user object and return it in the response
-          const token = jwt.sign(userJson, process.env.JWT_SECRET);
-          return res.json({ userJson, token });
-        });
-      })(req, res);
-    };
+    });
     router.post("/login", AccessChecker.canViewSessionUser, loginCallback);
     // user content endpoints (log-out)
     const logoutCallback = (request, response, next) => {

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -37,7 +37,7 @@ export class ViewRouter {
   #createGetRoutes(router) {
     router.get("/", AccessChecker.canViewContent, async (request, response) => {
       const scrapConfig = await ScrapConfig.getDatabaseModel().findById(request.user.config);
-      response.status(200).header("x-auth-token", request.session.jwt).render("index", {
+      response.render("index", {
         title: "scraper configuration",
         type: "home",
         user: request.user.name,
@@ -45,7 +45,6 @@ export class ViewRouter {
         categories: this.#getSupportedCategories(),
         currencies: this.#getSupportedCurrencies(),
       });
-      request.session.jwt = null;
     });
     router.get("/status", AccessChecker.canViewContent, (request, response) =>
       response.render("status", {

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -37,11 +37,10 @@ export class ViewRouter {
   #createGetRoutes(router) {
     router.get("/", AccessChecker.canViewContent, async (request, response) => {
       const scrapConfig = await ScrapConfig.getDatabaseModel().findById(request.user.config);
-      response.render("index", {
+      response.status(200).header("x-auth-token", request.session.jwt).render("index", {
         title: "scraper configuration",
         type: "home",
         user: request.user.name,
-        token: request.session.jwt,
         content: scrapConfig.toJSON(),
         categories: this.#getSupportedCategories(),
         currencies: this.#getSupportedCurrencies(),

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -41,10 +41,12 @@ export class ViewRouter {
         title: "scraper configuration",
         type: "home",
         user: request.user.name,
+        token: request.session.jwt,
         content: scrapConfig.toJSON(),
         categories: this.#getSupportedCategories(),
         currencies: this.#getSupportedCurrencies(),
       });
+      request.session.jwt = null;
     });
     router.get("/status", AccessChecker.canViewContent, (request, response) =>
       response.render("status", {

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -76,7 +76,7 @@ export class ViewRouter {
       if (!imageMimeRegex.test(fileObject.mimetype)) {
         return response.status(400).json("Provided file is NOT an image file");
       }
-      const newImagePath = path.join(this.#dataFilePath, request.user.email, "images", fileObject.name)
+      const newImagePath = path.join(this.#dataFilePath, request.user.email, "images", fileObject.name);
       const newImageRoot = path.dirname(newImagePath);
       if (!fs.existsSync(newImageRoot)) {
         fs.mkdirSync(newImageRoot, { recursive: true });

--- a/test/components/web-server.test.js
+++ b/test/components/web-server.test.js
@@ -5,6 +5,7 @@ import { ComponentType, LogLevel } from "../../config/app-types.js";
 const TEST_PORT = 1234;
 
 describe("run() method", () => {
+  process.env.JWT_SECRET = "run_tests_secret";
   test("should start server and not throw when no INIT components", async () => {
     const config = { usersDataConfig: {}, minLogLevel: LogLevel.INFO, serverConfig: { port: TEST_PORT } };
     const components = new WebComponents(config);
@@ -56,6 +57,7 @@ describe("run() method", () => {
 });
 
 describe("shutdown() method", () => {
+  process.env.JWT_SECRET = "shutdown_tests_secret";
   test("does not throw when session started", async () => {
     const config = { usersDataConfig: {}, minLogLevel: LogLevel.INFO, serverConfig: { port: TEST_PORT } };
     const components = new WebComponents(config);

--- a/test/middleware/access-checker.test.js
+++ b/test/middleware/access-checker.test.js
@@ -114,8 +114,22 @@ describe("canViewContent() method", () => {
 
 describe("canViewSessionUser() method", () => {
   test("should not redirect when not authorized", async () => {
-    const requestObj = { isAuthenticated: () => false };
     const invokeState = { redirect: "", next: false };
+    const requestObj = { 
+      isAuthenticated: () => false,
+      app: {
+        locals: {
+          passport: {
+            authenticate: (name, options) => {
+              return (req, res, next) => {
+                invokeState.redirect = "/";
+                invokeState.next = false;
+              }
+            },
+          },
+        },
+      }
+    };
     const mockedRes = { redirect: (input) => (invokeState.redirect = input) };
     const mockedNext = () => (invokeState.next = true);
     AccessChecker.canViewSessionUser(requestObj, mockedRes, mockedNext);
@@ -123,8 +137,22 @@ describe("canViewSessionUser() method", () => {
     expect(invokeState.next).toBe(true);
   });
   test("should redirect when authorized", async () => {
-    const requestObj = { isAuthenticated: () => true };
     const invokeState = { redirect: "", next: false };
+    const requestObj = { 
+      isAuthenticated: () => true,
+      app: {
+        locals: {
+          passport: {
+            authenticate: (name, options) => {
+              return (req, res, next) => {
+                invokeState.redirect = "/";
+                invokeState.next = false;
+              }
+            },
+          },
+        },
+      }
+    };
     const mockedRes = { redirect: (input) => (invokeState.redirect = input) };
     const mockedNext = () => (invokeState.next = true);
     AccessChecker.canViewSessionUser(requestObj, mockedRes, mockedNext);

--- a/test/middleware/access-checker.test.js
+++ b/test/middleware/access-checker.test.js
@@ -2,8 +2,23 @@ import { AccessChecker } from "../../src/middleware/access-checker.js";
 
 describe("canReceiveData() method", () => {
   test("shouldn't do anything when authorized", async () => {
-    const requestObj = { isAuthenticated: () => true };
     const invokeState = { status: 200, text: "", next: false };
+    const requestObj = { 
+      isAuthenticated: () => true,
+      app: {
+        locals: {
+          passport: {
+            authenticate: (name, options) => {
+              return (req, res, next) => {
+                invokeState.status = 401;
+                invokeState.text = "Unauthroized";
+                invokeState.next = false;
+              }
+            },
+          },
+        },
+      }
+    };
     const mockedRes = {
       status: (input) => {
         invokeState.status = input;
@@ -17,8 +32,23 @@ describe("canReceiveData() method", () => {
     expect(invokeState.next).toBe(true);
   });
   test("should throw error 401 when not authorized", async () => {
-    const requestObj = { isAuthenticated: () => false };
     const invokeState = { status: 200, text: "", next: false };
+    const requestObj = { 
+      isAuthenticated: () => false,
+      app: {
+        locals: {
+          passport: {
+            authenticate: (name, options) => {
+              return (req, res, next) => {
+                invokeState.status = 401;
+                invokeState.text = "Unauthroized";
+                invokeState.next = false;
+              }
+            },
+          },
+        },
+      }
+    };
     const mockedRes = {
       status: (input) => {
         invokeState.status = input;
@@ -28,7 +58,7 @@ describe("canReceiveData() method", () => {
     const mockedNext = () => (invokeState.next = true);
     AccessChecker.canReceiveData(requestObj, mockedRes, mockedNext);
     expect(invokeState.status).toBe(401);
-    expect(invokeState.text).toBe("Not authenticated");
+    expect(invokeState.text).toBe("Unauthroized");
     expect(invokeState.next).toBe(false);
   });
 });

--- a/test/middleware/access-checker.test.js
+++ b/test/middleware/access-checker.test.js
@@ -65,8 +65,22 @@ describe("canReceiveData() method", () => {
 
 describe("canViewContent() method", () => {
   test("should not redirect when authorized", async () => {
-    const requestObj = { isAuthenticated: () => true };
     const invokeState = { redirect: "", next: false };
+    const requestObj = { 
+      isAuthenticated: () => true,
+      app: {
+        locals: {
+          passport: {
+            authenticate: (name, options) => {
+              return (req, res, next) => {
+                invokeState.redirect = "/auth/login";
+                invokeState.next = false;
+              }
+            },
+          },
+        },
+      }
+    };
     const mockedRes = { redirect: (input) => (invokeState.redirect = input) };
     const mockedNext = () => (invokeState.next = true);
     AccessChecker.canViewContent(requestObj, mockedRes, mockedNext);
@@ -74,8 +88,22 @@ describe("canViewContent() method", () => {
     expect(invokeState.next).toBe(true);
   });
   test("should redirect when not authorized", async () => {
-    const requestObj = { isAuthenticated: () => false };
     const invokeState = { redirect: "", next: false };
+    const requestObj = { 
+      isAuthenticated: () => false,
+      app: {
+        locals: {
+          passport: {
+            authenticate: (name, options) => {
+              return (req, res, next) => {
+                invokeState.redirect = "/auth/login";
+                invokeState.next = false;
+              }
+            },
+          },
+        },
+      }
+    };
     const mockedRes = { redirect: (input) => (invokeState.redirect = input) };
     const mockedNext = () => (invokeState.next = true);
     AccessChecker.canViewContent(requestObj, mockedRes, mockedNext);

--- a/test/middleware/access-checker.test.js
+++ b/test/middleware/access-checker.test.js
@@ -3,7 +3,7 @@ import { AccessChecker } from "../../src/middleware/access-checker.js";
 describe("canReceiveData() method", () => {
   test("shouldn't do anything when authorized", async () => {
     const invokeState = { status: 200, text: "", next: false };
-    const requestObj = { 
+    const requestObj = {
       isAuthenticated: () => true,
       app: {
         locals: {
@@ -13,11 +13,11 @@ describe("canReceiveData() method", () => {
                 invokeState.status = 401;
                 invokeState.text = "Unauthroized";
                 invokeState.next = false;
-              }
+              };
             },
           },
         },
-      }
+      },
     };
     const mockedRes = {
       status: (input) => {
@@ -33,7 +33,7 @@ describe("canReceiveData() method", () => {
   });
   test("should throw error 401 when not authorized", async () => {
     const invokeState = { status: 200, text: "", next: false };
-    const requestObj = { 
+    const requestObj = {
       isAuthenticated: () => false,
       app: {
         locals: {
@@ -43,11 +43,11 @@ describe("canReceiveData() method", () => {
                 invokeState.status = 401;
                 invokeState.text = "Unauthroized";
                 invokeState.next = false;
-              }
+              };
             },
           },
         },
-      }
+      },
     };
     const mockedRes = {
       status: (input) => {
@@ -66,7 +66,7 @@ describe("canReceiveData() method", () => {
 describe("canViewContent() method", () => {
   test("should not redirect when authorized", async () => {
     const invokeState = { redirect: "", next: false };
-    const requestObj = { 
+    const requestObj = {
       isAuthenticated: () => true,
       app: {
         locals: {
@@ -75,11 +75,11 @@ describe("canViewContent() method", () => {
               return (req, res, next) => {
                 invokeState.redirect = "/auth/login";
                 invokeState.next = false;
-              }
+              };
             },
           },
         },
-      }
+      },
     };
     const mockedRes = { redirect: (input) => (invokeState.redirect = input) };
     const mockedNext = () => (invokeState.next = true);
@@ -89,7 +89,7 @@ describe("canViewContent() method", () => {
   });
   test("should redirect when not authorized", async () => {
     const invokeState = { redirect: "", next: false };
-    const requestObj = { 
+    const requestObj = {
       isAuthenticated: () => false,
       app: {
         locals: {
@@ -98,11 +98,11 @@ describe("canViewContent() method", () => {
               return (req, res, next) => {
                 invokeState.redirect = "/auth/login";
                 invokeState.next = false;
-              }
+              };
             },
           },
         },
-      }
+      },
     };
     const mockedRes = { redirect: (input) => (invokeState.redirect = input) };
     const mockedNext = () => (invokeState.next = true);
@@ -115,7 +115,7 @@ describe("canViewContent() method", () => {
 describe("canViewSessionUser() method", () => {
   test("should not redirect when not authorized", async () => {
     const invokeState = { redirect: "", next: false };
-    const requestObj = { 
+    const requestObj = {
       isAuthenticated: () => false,
       app: {
         locals: {
@@ -124,11 +124,11 @@ describe("canViewSessionUser() method", () => {
               return (req, res, next) => {
                 invokeState.redirect = "/";
                 invokeState.next = false;
-              }
+              };
             },
           },
         },
-      }
+      },
     };
     const mockedRes = { redirect: (input) => (invokeState.redirect = input) };
     const mockedNext = () => (invokeState.next = true);
@@ -138,7 +138,7 @@ describe("canViewSessionUser() method", () => {
   });
   test("should redirect when authorized", async () => {
     const invokeState = { redirect: "", next: false };
-    const requestObj = { 
+    const requestObj = {
       isAuthenticated: () => true,
       app: {
         locals: {
@@ -147,11 +147,11 @@ describe("canViewSessionUser() method", () => {
               return (req, res, next) => {
                 invokeState.redirect = "/";
                 invokeState.next = false;
-              }
+              };
             },
           },
         },
-      }
+      },
     };
     const mockedRes = { redirect: (input) => (invokeState.redirect = input) };
     const mockedNext = () => (invokeState.next = true);

--- a/test/routes/view/auth-router.test.js
+++ b/test/routes/view/auth-router.test.js
@@ -21,6 +21,7 @@ describe("createRoutes() method", () => {
     const expectedRoutes = [
       { path: "/register", method: "get" },
       { path: "/login", method: "get" },
+      { path: "/token", method: "get" },
       { path: "/register", method: "post" },
       { path: "/login", method: "post" },
       { path: "/logout", method: "post" },

--- a/test/routes/view/auth-router.test.js
+++ b/test/routes/view/auth-router.test.js
@@ -91,6 +91,11 @@ describe("created auth GET routes", () => {
     expect(response.text).toContain('<i class="fa fa-sign-in"></i> login with email');
     expect(response.text).toContain('<p>not registered? go to <a href="/auth/register">register</a> page.</p>');
   });
+  test("returns correct result using /token endpoint", async () => {
+    const response = await testAgent.get("/auth/token");
+    expect(response.statusCode).toBe(302);
+    expect(response.text).toBe("Found. Redirecting to /auth/login");
+  });
 });
 
 describe("created auth POST routes", () => {

--- a/test/routes/view/auth-router.test.js
+++ b/test/routes/view/auth-router.test.js
@@ -14,6 +14,8 @@ import { engine } from "express-handlebars";
 
 jest.mock("../../../src/model/scrap-config.js");
 
+process.env.JWT_SECRET = "test_secret";
+
 describe("createRoutes() method", () => {
   test("returns correct number of routes", () => {
     const expectedRoutes = [

--- a/test/routes/view/auth-router.test.js
+++ b/test/routes/view/auth-router.test.js
@@ -58,6 +58,8 @@ describe("created auth GET routes", () => {
   testApp.use(passport.initialize());
   testApp.use(passport.session());
   testApp.use("/auth", testRouter.createRoutes());
+  // store passport configuration in app locals
+  testApp.locals.passport = passport;
   // retrieve underlying superagent to correctly persist sessions
   const testAgent = supertest.agent(testApp);
   test("returns correct result for unknown path", async () => {
@@ -113,6 +115,8 @@ describe("created auth POST routes", () => {
   testApp.use(passport.initialize());
   testApp.use(passport.session());
   testApp.use("/auth", testRouter.createRoutes());
+  // store passport configuration in app locals
+  testApp.locals.passport = passport;
   // retrieve underlying superagent to correctly persist sessions
   const testAgent = supertest.agent(testApp);
   test("returns correct result for unknown path", async () => {


### PR DESCRIPTION
This patch fixes #101 
Now after user logins correctly the frontend client will sent a request to receive a token. If session verification passes then a new JWT is returned to the client which stores it in LocalStorage and adds to further requests.