### PR TITLE
Added demo mode selection

### DIFF
--- a/src/components/web-server.js
+++ b/src/components/web-server.js
@@ -9,7 +9,7 @@ import { StatusRouter } from "../routes/api/status-router.js";
 import { StatusLogger } from "./status-logger.js";
 import { ViewRouter } from "../routes/view/view-router.js";
 
-import cors from "cors"
+import cors from "cors";
 import express from "express";
 import passport from "passport";
 import flash from "express-flash";
@@ -88,7 +88,7 @@ export class WebServer {
     server.use(flash());
     server.use(fileUpload(this.#getFileUploadConfiguration()));
     server.use(session(this.#getSessionConfiguration()));
-    server.use(cors(this.#getCorsConfiguration()))
+    server.use(cors(this.#getCorsConfiguration()));
     // initialize and configure passport
     server.use(passport.initialize());
     server.use(passport.session());
@@ -115,7 +115,7 @@ export class WebServer {
       abortOnLimit: true,
       limits: {
         fileSize: 10_000_000,
-      }
+      },
     };
   }
 
@@ -139,8 +139,8 @@ export class WebServer {
     return {
       origin: true,
       credentials: true,
-      methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
-      allowedHeaders: ['Origin', 'X-Requested-With', 'X-AUTHENTICATION', 'X-IP', 'Content-Type', 'Accept'],
+      methods: ["GET", "PUT", "POST", "DELETE", "OPTIONS"],
+      allowedHeaders: ["Origin", "X-Requested-With", "X-AUTHENTICATION", "X-IP", "Content-Type", "Accept"],
     };
   }
 }

--- a/src/components/web-server.js
+++ b/src/components/web-server.js
@@ -36,7 +36,7 @@ export class WebServer {
   constructor(config, components) {
     this.#setupConfig = config;
     this.#components = components;
-    this.#authConfig = new AuthConfig(passport, components);
+    this.#authConfig = new AuthConfig(passport, components, config.demoConfig);
     this.#status = new StatusLogger(WebServer.#LOGGER_NAME, config.minLogLevel);
     this.#status.info("Created");
   }

--- a/src/components/web-server.js
+++ b/src/components/web-server.js
@@ -36,7 +36,7 @@ export class WebServer {
   constructor(config, components) {
     this.#setupConfig = config;
     this.#components = components;
-    this.#authConfig = new AuthConfig(passport, components, config.demoConfig);
+    this.#authConfig = new AuthConfig(passport, components, config.authConfig);
     this.#status = new StatusLogger(WebServer.#LOGGER_NAME, config.minLogLevel);
     this.#status.info("Created");
   }

--- a/src/config/app-config.js
+++ b/src/config/app-config.js
@@ -41,6 +41,9 @@ export class AppConfig {
         password: process.env.DB_PASSWORD || "",
         timeout: parseInt(process.env.DB_TIMEOUT) || 15_000,
       },
+      demoConfig: {
+        mode: process.env.DEMO_MODE || "duplicate",
+      },
       scraperConfig: {
         loginInterval: 30,
         scrapInterval: 30_000,

--- a/src/config/app-config.js
+++ b/src/config/app-config.js
@@ -41,8 +41,8 @@ export class AppConfig {
         password: process.env.DB_PASSWORD || "",
         timeout: parseInt(process.env.DB_TIMEOUT) || 15_000,
       },
-      demoConfig: {
-        mode: process.env.DEMO_MODE || "duplicate",
+      authConfig: {
+        demoMode: process.env.DEMO_MODE || "duplicate",
       },
       scraperConfig: {
         loginInterval: 30,

--- a/src/config/app-config.js
+++ b/src/config/app-config.js
@@ -1,4 +1,4 @@
-import { LogLevel } from "./app-types.js";
+import { DemoMode, LogLevel } from "./app-types.js";
 
 import dotenv from "dotenv";
 import path from "path";
@@ -42,7 +42,7 @@ export class AppConfig {
         timeout: parseInt(process.env.DB_TIMEOUT) || 15_000,
       },
       authConfig: {
-        demoMode: process.env.DEMO_MODE || "duplicate",
+        demoMode: new DemoMode(process.env.DEMO_MODE) || DemoMode.DUPLICATE,
       },
       scraperConfig: {
         loginInterval: 30,

--- a/src/config/app-types.js
+++ b/src/config/app-types.js
@@ -93,6 +93,11 @@ class DemoMode {
     this.mode = mode;
   }
 
+  /**
+   * Compares this demo modej with other one and determines if they are equal
+   * @param {Object} other Another demo mode object to compare
+   * @returns true if checked demo mode matches this one
+   */
   equals(other) {
     return this.mode === other.mode;
   }

--- a/src/config/app-types.js
+++ b/src/config/app-types.js
@@ -92,6 +92,10 @@ class DemoMode {
   constructor(mode) {
     this.mode = mode;
   }
+
+  equals(other) {
+    return this.mode === other.mode;
+  }
 }
 
 export { LogLevel, ComponentType, ComponentStatus, DemoMode };

--- a/src/config/app-types.js
+++ b/src/config/app-types.js
@@ -77,4 +77,21 @@ class ComponentStatus {
   }
 }
 
-export { LogLevel, ComponentType, ComponentStatus };
+/**
+ * Class representing the demo session mode
+ * It implements an enum with values: OVERWRITE, DUPLICATE
+ */
+class DemoMode {
+  static OVERWRITE = new DemoMode("overwrite");
+  static DUPLICATE = new DemoMode("duplicate");
+
+  /**
+   * Creates an object representing demo mode setting
+   * @param {String} mode The demo mode value
+   */
+  constructor(mode) {
+    this.mode = mode;
+  }
+}
+
+export { LogLevel, ComponentType, ComponentStatus, DemoMode };

--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -13,15 +13,18 @@ export class AuthConfig {
 
   #components = undefined;
   #passport = undefined;
+  #demoConfig = undefined;
 
   /**
    * Creates a new configuration object for managing authentication settings
    * @param {Object} passport The login/register dispatcher object to be configured
    * @param {Object} components The web components used in authentication process
+   * @param {Object} config The object containing demo session configuration
    */
-  constructor(passport, components) {
+  constructor(passport, components, config) {
     this.#components = components;
     this.#passport = passport;
+    this.#demoConfig = config;
   }
 
   /**

--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -183,7 +183,7 @@ export class AuthConfig {
           return done(null, false, { message: "Cannot start authenticate components. Please try again." });
         }
         // create demo session duplicate if needed
-        if (DemoMode.DUPLICATE.mode === this.#config.demoMode) {
+        if (DemoMode.DUPLICATE.equals(this.#config.demoMode)) {
           // create a clone of the base demo user with updated email and last login entry
           user[0].hostUser = user[0]._id;
           user[0]._id = new mongoose.Types.ObjectId();

--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -183,7 +183,7 @@ export class AuthConfig {
           return done(null, false, { message: "Cannot start authenticate components. Please try again." });
         }
         // create demo session duplicate if needed
-        if (DemoMode.DUPLICATE.equals(this.#config.demoMode)) {
+        if (!DemoMode.OVERWRITE.equals(this.#config.demoMode)) {
           // create a clone of the base demo user with updated email and last login entry
           user[0].hostUser = user[0]._id;
           user[0]._id = new mongoose.Types.ObjectId();

--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -13,18 +13,18 @@ export class AuthConfig {
 
   #components = undefined;
   #passport = undefined;
-  #demoConfig = undefined;
+  #config = undefined;
 
   /**
    * Creates a new configuration object for managing authentication settings
    * @param {Object} passport The login/register dispatcher object to be configured
    * @param {Object} components The web components used in authentication process
-   * @param {Object} config The object containing demo session configuration
+   * @param {Object} config The object containing initial auth configuration values
    */
   constructor(passport, components, config) {
     this.#components = components;
     this.#passport = passport;
-    this.#demoConfig = config;
+    this.#config = config;
   }
 
   /**
@@ -183,7 +183,7 @@ export class AuthConfig {
           return done(null, false, { message: "Cannot start authenticate components. Please try again." });
         }
         // create demo session duplicate if needed
-        if (DemoMode.DUPLICATE.mode === this.#demoConfig.mode) {
+        if (DemoMode.DUPLICATE.mode === this.#config.demoMode) {
           // create a clone of the base demo user with updated email and last login entry
           user[0].hostUser = user[0]._id;
           user[0]._id = new mongoose.Types.ObjectId();


### PR DESCRIPTION
This patch added two different demo modes: DUPLICATE and OVERWRITE.
The first one is the go-to solution. The latter is needed to change the base demo setting and shouldn't be used in production.
The mode can be selected in the environment variables. If omitted then default one (DUPLICATE) will be used.
