### PR TITLE
Fixed CI sandbox error on newest Ubuntu

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: ['18.x', '20.x', '22.x']
     steps:
     - name: Checkout the repository
-      run: actions/checkout@v4
+      uses: actions/checkout@v4
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,8 +14,9 @@ jobs:
       matrix:
         node-version: ['18.x', '20.x', '22.x']
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Checkout the repository
+      run: actions/checkout@v4
+    - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,10 +25,7 @@ jobs:
       run: npm ci
     - name: Build project
       run: npm run build --if-present
-    - name: Allow creation of user namespaces (e.g. to the unshare command)
+    - name: Disable Ubuntu's security feature
       run: |
-        # .. so that we don't get error:
-        # unshare: write failed /proc/self/uid_map: Operation not permitted
-        # Idea from https://github.com/YoYoGames/GameMaker-Bugs/issues/6015#issuecomment-2135552784 .
         sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
     - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,7 +28,7 @@ jobs:
       run: npm ci
     - name: Build project
       run: npm run build --if-present
-    - name: Setting Chromium sandbox owner and mode
+    - name: Setting Chromium sandbox file mode to be executed as root
       run: |
         sudo chmod 4755 /opt/google/chrome/chrome-sandbox
     - name: Run CI tests for project

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,4 +28,5 @@ jobs:
     - name: Disable Ubuntu's security feature
       run: |
         sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
-    - run: npm test
+    - name: Run CI tests for project
+      run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,12 +21,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - name: Clean install project and all packages that it depends on
+      run: npm ci
+    - name: Build project
+      run: npm run build --if-present
     - name: Allow creation of user namespaces (e.g. to the unshare command)
       run: |
         # .. so that we don't get error:
         # unshare: write failed /proc/self/uid_map: Operation not permitted
         # Idea from https://github.com/YoYoGames/GameMaker-Bugs/issues/6015#issuecomment-2135552784 .
         sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
-    - run: npm ci
-    - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,6 +20,12 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - name: Allow creation of user namespaces (e.g. to the unshare command)
+      run: |
+        # .. so that we don't get error:
+        # unshare: write failed /proc/self/uid_map: Operation not permitted
+        # Idea from https://github.com/YoYoGames/GameMaker-Bugs/issues/6015#issuecomment-2135552784 .
+        sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,5 +28,8 @@ jobs:
       run: npm ci
     - name: Build project
       run: npm run build --if-present
+    - name: Setting Chromium sandbox owner and mode
+      run: |
+        sudo chmod 4755 /opt/google/chrome/chrome-sandbox
     - name: Run CI tests for project
       run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: 'main'
 
+env:
+  CHROME_DEVEL_SANDBOX: /opt/google/chrome/chrome-sandbox
+
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -25,8 +28,5 @@ jobs:
       run: npm ci
     - name: Build project
       run: npm run build --if-present
-    - name: Disable Ubuntu's security feature
-      run: |
-        sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
     - name: Run CI tests for project
       run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,7 +29,6 @@ jobs:
     - name: Build project
       run: npm run build --if-present
     - name: Setting Chromium sandbox file mode to be executed as root
-      run: |
-        sudo chmod 4755 /opt/google/chrome/chrome-sandbox
+      run: sudo chmod 4755 /opt/google/chrome/chrome-sandbox
     - name: Run CI tests for project
       run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: ['18.x', '20.x', '22.x']


### PR DESCRIPTION
This patch fixes #118 
Now CI is passing on Ubuntu 23+ version 