### PR TITLE
Use JWT in data endpoints for implicitly retrieving the owner

### DIFF
--- a/docs/requests/api-data/get_data-all.bru
+++ b/docs/requests/api-data/get_data-all.bru
@@ -5,13 +5,13 @@ meta {
 }
 
 get {
-  url: http://localhost:5000/api/v1/data?owner=bruno@test.ci
+  url: http://localhost:5000/api/v1/data
   body: none
-  auth: none
+  auth: bearer
 }
 
-params:query {
-  owner: bruno@test.ci
+auth:bearer {
+  token: {{demo-token}}
 }
 
 tests {

--- a/docs/requests/api-data/get_data-category.bru
+++ b/docs/requests/api-data/get_data-category.bru
@@ -5,14 +5,17 @@ meta {
 }
 
 get {
-  url: http://localhost:5000/api/v1/data?owner=bruno@test.ci&category=📈
+  url: http://localhost:5000/api/v1/data?category=📈
   body: none
-  auth: none
+  auth: bearer
 }
 
 params:query {
-  owner: bruno@test.ci
   category: 📈
+}
+
+auth:bearer {
+  token: {{demo-token}}
 }
 
 tests {

--- a/docs/requests/api-data/get_data-empty.bru
+++ b/docs/requests/api-data/get_data-empty.bru
@@ -5,14 +5,17 @@ meta {
 }
 
 get {
-  url: http://localhost:5000/api/v1/data?owner=bruno@test.ci&name=unknown
+  url: http://localhost:5000/api/v1/data?name=unknown
   body: none
-  auth: none
+  auth: bearer
 }
 
 params:query {
-  owner: bruno@test.ci
   name: unknown
+}
+
+auth:bearer {
+  token: {{demo-token}}
 }
 
 tests {

--- a/docs/requests/api-data/get_data-error.bru
+++ b/docs/requests/api-data/get_data-error.bru
@@ -1,13 +1,21 @@
 meta {
   name: get_data-error
   type: http
-  seq: 1
+  seq: 2
 }
 
 get {
-  url: http://localhost:5000/api/v1/data
+  url: http://localhost:5000/api/v1/data?owner=unknown
   body: none
-  auth: none
+  auth: bearer
+}
+
+params:query {
+  owner: unknown
+}
+
+auth:bearer {
+  token: {{demo-token}}
 }
 
 tests {
@@ -20,7 +28,7 @@ tests {
   });
 
   test("data has correct content length", function() {
-    expect(res.getHeader("content-length")).to.equal("153");
+    expect(res.getHeader("content-length")).to.equal("180");
   });
 
   test("data has correct top-level structure", function() {
@@ -53,9 +61,9 @@ tests {
   test("data has correct element values", function() {
     const data = res.getBody();
     expect(data[0].instancePath).to.equal("");
-    expect(data[0].schemaPath).to.equal("#/required");
-    expect(data[0].keyword).to.equal("required");
-    expect(data[0].params).to.deep.equal({missingProperty: "owner"});
-    expect(data[0].message).to.equal("must have required property 'owner'");
+    expect(data[0].schemaPath).to.equal("#/additionalProperties");
+    expect(data[0].keyword).to.equal("additionalProperties");
+    expect(data[0].params).to.deep.equal({additionalProperty: "owner"});
+    expect(data[0].message).to.equal("must NOT have additional properties");
   });
 }

--- a/docs/requests/api-data/get_data-name.bru
+++ b/docs/requests/api-data/get_data-name.bru
@@ -5,14 +5,17 @@ meta {
 }
 
 get {
-  url: http://localhost:5000/api/v1/data?owner=bruno@test.ci&name=games
+  url: http://localhost:5000/api/v1/data?name=games
   body: none
-  auth: none
+  auth: bearer
 }
 
 params:query {
-  owner: bruno@test.ci
   name: games
+}
+
+auth:bearer {
+  token: {{demo-token}}
 }
 
 tests {

--- a/docs/requests/api-data/get_data-unauthorized.bru
+++ b/docs/requests/api-data/get_data-unauthorized.bru
@@ -1,7 +1,7 @@
 meta {
-  name: get_data-invalid
+  name: get_data-unauthorized
   type: http
-  seq: 2
+  seq: 1
 }
 
 get {
@@ -16,15 +16,7 @@ params:query {
 
 tests {
   test("data is correctly received", function() {
-    expect(res.getStatus()).to.equal(400);
-  });
-
-  test("data received JSON data", function() {
-    expect(res.getHeader("content-type")).to.equal("application/json; charset=utf-8");
-  });
-
-  test("data has correct content length", function() {
-    expect(res.getHeader("content-length")).to.equal("29");
+    expect(res.getStatus()).to.equal(401);
   });
 
   test("data has correct top-level structure", function() {
@@ -34,6 +26,6 @@ tests {
 
   test("data has correct top-level value", function() {
     const data = res.getBody();
-    expect(data).to.equal("Invalid data owner provided");
+    expect(data).to.equal("Unauthorized");
   });
 }

--- a/src/routes/api/data-router.js
+++ b/src/routes/api/data-router.js
@@ -4,6 +4,7 @@ import Ajv from "ajv";
 import express from "express";
 import fs from "fs";
 import path from "path";
+import jwt from "jsonwebtoken";
 
 export class DataRouter {
   #dataFileConfig = undefined;
@@ -29,7 +30,9 @@ export class DataRouter {
         response.status(400).json(validationResult.cause);
         return;
       }
-      const userPath = path.join(this.#dataFileConfig.path, request.query.owner, this.#dataFileConfig.file);
+      const token = request.headers["authorization"].split(" ")[1];
+      const user = jwt.verify(token, process.env.JWT_SECRET);
+      const userPath = path.join(this.#dataFileConfig.path, user.email, this.#dataFileConfig.file);
       if (!fs.existsSync(userPath)) {
         response.status(400).json(`Invalid data owner provided`);
         return;

--- a/src/routes/api/data-router.js
+++ b/src/routes/api/data-router.js
@@ -56,11 +56,9 @@ export class DataRouter {
       type: "object",
       additionalProperties: false,
       properties: {
-        owner: { type: "string" },
         name: { type: "string" },
         category: { type: "string" },
       },
-      required: ["owner"],
     });
     return {
       valid: validate(params),

--- a/src/routes/api/data-router.js
+++ b/src/routes/api/data-router.js
@@ -1,3 +1,5 @@
+import { AccessChecker } from "../../middleware/access-checker.js";
+
 import Ajv from "ajv";
 import express from "express";
 import fs from "fs";
@@ -21,7 +23,7 @@ export class DataRouter {
   createRoutes() {
     const router = express.Router();
     // create endpoint for receiving data according specified query param filters
-    router.get("/", (request, response) => {
+    router.get("/", AccessChecker.canReceiveData, (request, response) => {
       const validationResult = this.#validateQueryParams(request.query);
       if (!validationResult.valid) {
         response.status(400).json(validationResult.cause);

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -225,14 +225,15 @@ describe("created data GET routes", () => {
           response: [],
         },
       ],
-      // [
-      //   "query contains existing name and not existing category",
-      //   { owner: "owner", name: "games", category: "unknown" },
-      //   {
-      //     status: 200,
-      //     response: [],
-      //   },
-      // ],
+      [
+        "query contains existing name and not existing category",
+        testOwner,
+        { name: "games", category: "unknown" },
+        {
+          status: 200,
+          response: [],
+        },
+      ],
       // [
       //   "query contains not existing name and existing category",
       //   { owner: "owner", name: "unknown", category: "👕" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -152,14 +152,15 @@ describe("created data GET routes", () => {
           ],
         },
       ],
-      // [
-      //   "query contains not existing name",
-      //   { owner: "owner", name: "unknown" },
-      //   {
-      //     status: 200,
-      //     response: [],
-      //   },
-      // ],
+      [
+        "query contains not existing name for valid user",
+        testOwner,
+        { name: "unknown" },
+        {
+          status: 200,
+          response: [],
+        },
+      ],
       // [
       //   "query contains existing category",
       //   { owner: "owner", category: "🎮" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -78,22 +78,41 @@ describe("created data GET routes", () => {
           ],
         },
       ],
-      // [
-      //   "query is empty",
-      //   {},
-      //   {
-      //     status: 400,
-      //     response: [
-      //       {
-      //         instancePath: "",
-      //         keyword: "required",
-      //         message: "must have required property 'owner'",
-      //         params: { missingProperty: "owner" },
-      //         schemaPath: "#/required",
-      //       },
-      //     ],
-      //   },
-      // ],
+      [
+        "query is empty",
+        {},
+        {
+          status: 200,
+          response: [
+            {
+              name: "clothes",
+              category: "👕",
+              items: [
+                {
+                  status: "OK",
+                  name: "t-shirt Regular Fit",
+                  icon: "",
+                  price: "29.99",
+                  currency: "PLN",
+                },
+              ],
+            },
+            {
+              name: "games",
+              category: "🎮",
+              items: [
+                {
+                  status: "OK",
+                  name: "Diablo IV",
+                  icon: "",
+                  price: "349.99",
+                  currency: "PLN",
+                },
+              ],
+            },
+          ],
+        },
+      ],
       // [
       //   "query contains invalid user",
       //   { owner: "invalid" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -271,6 +271,7 @@ describe("created data GET routes", () => {
       //   },
       // ],
     ])("%s", async (_, inputQuery, expected) => {
+      testAgent.set({ Authorization: `Token JWT-MOCKED-TOKEN` });
       const response = await testAgent.get("/data").query(inputQuery);
       expect(response.statusCode).toBe(expected.status);
       expect(response.body).toStrictEqual(expected.response);

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -46,7 +46,6 @@ describe("createRoutes() method", () => {
 
 describe("created data GET routes", () => {
   const testConfig = { path: path.parse(testDataPath).root, file: "data.json" };
-  jest.spyOn(jsonwebtoken, "verify").mockReturnValue({ email: testOwner });
   // configue test express app server
   const testApp = express();
   testApp.use(express.json());
@@ -70,6 +69,7 @@ describe("created data GET routes", () => {
     it.each([
       [
         "query has invalid structure",
+        testOwner,
         { unknown: "status" },
         {
           status: 400,
@@ -86,6 +86,7 @@ describe("created data GET routes", () => {
       ],
       [
         "query is empty",
+        testOwner,
         {},
         {
           status: 200,
@@ -276,8 +277,11 @@ describe("created data GET routes", () => {
       //     response: [],
       //   },
       // ],
-    ])("%s", async (_, inputQuery, expected) => {
+    ])("%s", async (_, mockOwner, inputQuery, expected) => {
+      // prepare JWT authentication mock
       testAgent.set({ Authorization: `Token JWT-MOCKED-TOKEN` });
+      jest.spyOn(jsonwebtoken, "verify").mockReturnValue({ email: mockOwner });
+      // send request and check response
       const response = await testAgent.get("/data").query(inputQuery);
       expect(response.statusCode).toBe(expected.status);
       expect(response.body).toStrictEqual(expected.response);

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -48,6 +48,10 @@ describe("created data GET routes", () => {
   testApp.use("/auth", createMockAuthRouter());
   // retrieve underlying superagent to correctly persist sessions
   const testAgent = supertest.agent(testApp);
+  beforeAll(async () => {
+    const mockAuth = { mail: "owner", pass: "test-secret" };
+    await testAgent.post("/auth/login").send(mockAuth);
+  });
   test("returns correct result for unknown path", async () => {
     const response = await testClient.get("/data/unknown");
     expect(response.statusCode).toBe(404);

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -216,14 +216,15 @@ describe("created data GET routes", () => {
           ],
         },
       ],
-      // [
-      //   "query contains existing but not matching name and category",
-      //   { owner: "owner", name: "games", category: "👕" },
-      //   {
-      //     status: 200,
-      //     response: [],
-      //   },
-      // ],
+      [
+        "query contains existing but not matching name and category for valid user",
+        testOwner,
+        { name: "games", category: "👕" },
+        {
+          status: 200,
+          response: [],
+        },
+      ],
       // [
       //   "query contains existing name and not existing category",
       //   { owner: "owner", name: "games", category: "unknown" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -129,28 +129,29 @@ describe("created data GET routes", () => {
           ],
         },
       ],
-      // [
-      //   "query contains existing name",
-      //   { owner: "owner", name: "clothes" },
-      //   {
-      //     status: 200,
-      //     response: [
-      //       {
-      //         name: "clothes",
-      //         category: "👕",
-      //         items: [
-      //           {
-      //             status: "OK",
-      //             name: "t-shirt Regular Fit",
-      //             icon: "",
-      //             price: "29.99",
-      //             currency: "PLN",
-      //           },
-      //         ],
-      //       },
-      //     ],
-      //   },
-      // ],
+      [
+        "query contains existing name",
+        testOwner,
+        { name: "clothes" },
+        {
+          status: 200,
+          response: [
+            {
+              name: "clothes",
+              category: "👕",
+              items: [
+                {
+                  status: "OK",
+                  name: "t-shirt Regular Fit",
+                  icon: "",
+                  price: "29.99",
+                  currency: "PLN",
+                },
+              ],
+            },
+          ],
+        },
+      ],
       // [
       //   "query contains not existing name",
       //   { owner: "owner", name: "unknown" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -234,14 +234,15 @@ describe("created data GET routes", () => {
           response: [],
         },
       ],
-      // [
-      //   "query contains not existing name and existing category",
-      //   { owner: "owner", name: "unknown", category: "👕" },
-      //   {
-      //     status: 200,
-      //     response: [],
-      //   },
-      // ],
+      [
+        "query contains not existing name and existing category",
+        testOwner,
+        { name: "unknown", category: "👕" },
+        {
+          status: 200,
+          response: [],
+        },
+      ],
       // [
       //   "query contains not existing name and category",
       //   { owner: "owner", name: "unknown", category: "unknown" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -85,7 +85,7 @@ describe("created data GET routes", () => {
         },
       ],
       [
-        "query is empty with invalid user",
+        "query is empty for invalid user",
         "jwt-mock@owner.com",
         {},
         {
@@ -94,7 +94,7 @@ describe("created data GET routes", () => {
         },
       ],
       [
-        "query is empty with valid user",
+        "query is empty for valid user",
         testOwner,
         {},
         {
@@ -130,7 +130,7 @@ describe("created data GET routes", () => {
         },
       ],
       [
-        "query contains existing name",
+        "query contains existing name for valid user",
         testOwner,
         { name: "clothes" },
         {

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -85,7 +85,16 @@ describe("created data GET routes", () => {
         },
       ],
       [
-        "query is empty",
+        "query is empty with invalid user",
+        "jwt-mock@owner.com",
+        {},
+        {
+          status: 400,
+          response: "Invalid data owner provided",
+        },
+      ],
+      [
+        "query is empty with valid user",
         testOwner,
         {},
         {
@@ -120,50 +129,6 @@ describe("created data GET routes", () => {
           ],
         },
       ],
-      [
-        "query contains invalid user",
-        "jwt-mock@owner.com",
-        {},
-        {
-          status: 400,
-          response: "Invalid data owner provided",
-        },
-      ],
-      // [
-      //   "query contains valid user",
-      //   { owner: "owner" },
-      //   {
-      //     status: 200,
-      //     response: [
-      //       {
-      //         name: "clothes",
-      //         category: "👕",
-      //         items: [
-      //           {
-      //             status: "OK",
-      //             name: "t-shirt Regular Fit",
-      //             icon: "",
-      //             price: "29.99",
-      //             currency: "PLN",
-      //           },
-      //         ],
-      //       },
-      //       {
-      //         name: "games",
-      //         category: "🎮",
-      //         items: [
-      //           {
-      //             status: "OK",
-      //             name: "Diablo IV",
-      //             icon: "",
-      //             price: "349.99",
-      //             currency: "PLN",
-      //           },
-      //         ],
-      //       },
-      //     ],
-      //   },
-      // ],
       // [
       //   "query contains existing name",
       //   { owner: "owner", name: "clothes" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -4,12 +4,16 @@ import supertest from "supertest";
 import passport from "passport";
 import express from "express";
 import session from "express-session";
+import jsonwebtoken from "jsonwebtoken";
 import path from "path";
 import fs from "fs";
 
+import { jest } from "@jest/globals";
 import { Strategy } from "passport-local";
 
 const testDataPath = "./owner@test.com/data.json";
+
+jest.mock("jsonwebtoken");
 
 beforeAll(() => {
   createDataFile(testDataPath);
@@ -41,6 +45,7 @@ describe("createRoutes() method", () => {
 
 describe("created data GET routes", () => {
   const testConfig = { path: path.parse(testDataPath).root, file: "data.json" };
+  jest.spyOn(jsonwebtoken, "verify").mockReturnValue({ email: "owner@test.com" });
   // configue test express app server
   const testApp = express();
   testApp.use(express.json());

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -120,14 +120,15 @@ describe("created data GET routes", () => {
           ],
         },
       ],
-      // [
-      //   "query contains invalid user",
-      //   { owner: "invalid" },
-      //   {
-      //     status: 400,
-      //     response: "Invalid data owner provided",
-      //   },
-      // ],
+      [
+        "query contains invalid user",
+        "jwt-mock@owner.com",
+        {},
+        {
+          status: 400,
+          response: "Invalid data owner provided",
+        },
+      ],
       // [
       //   "query contains valid user",
       //   { owner: "owner" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -11,7 +11,8 @@ import fs from "fs";
 import { jest } from "@jest/globals";
 import { Strategy } from "passport-local";
 
-const testDataPath = "./owner@test.com/data.json";
+const testOwner = "owner@test.com";
+const testDataPath = `./${testOwner}/data.json`;
 
 jest.mock("jsonwebtoken");
 
@@ -45,7 +46,7 @@ describe("createRoutes() method", () => {
 
 describe("created data GET routes", () => {
   const testConfig = { path: path.parse(testDataPath).root, file: "data.json" };
-  jest.spyOn(jsonwebtoken, "verify").mockReturnValue({ email: "owner@test.com" });
+  jest.spyOn(jsonwebtoken, "verify").mockReturnValue({ email: testOwner });
   // configue test express app server
   const testApp = express();
   testApp.use(express.json());
@@ -58,7 +59,7 @@ describe("created data GET routes", () => {
   // retrieve underlying superagent to correctly persist sessions
   const testAgent = supertest.agent(testApp);
   beforeAll(async () => {
-    const mockAuth = { mail: "owner@test.com", pass: "test-secret" };
+    const mockAuth = { mail: testOwner, pass: "test-secret" };
     await testAgent.post("/auth/login").send(mockAuth);
   });
   test("returns correct result for unknown path", async () => {

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -9,7 +9,7 @@ import fs from "fs";
 
 import { Strategy } from "passport-local";
 
-const testDataPath = "./owner/data.json";
+const testDataPath = "./owner@test.com/data.json";
 
 beforeAll(() => {
   createDataFile(testDataPath);
@@ -53,7 +53,7 @@ describe("created data GET routes", () => {
   // retrieve underlying superagent to correctly persist sessions
   const testAgent = supertest.agent(testApp);
   beforeAll(async () => {
-    const mockAuth = { mail: "owner", pass: "test-secret" };
+    const mockAuth = { mail: "owner@test.com", pass: "test-secret" };
     await testAgent.post("/auth/login").send(mockAuth);
   });
   test("returns correct result for unknown path", async () => {

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -70,10 +70,10 @@ describe("created data GET routes", () => {
           response: [
             {
               instancePath: "",
-              keyword: "required",
-              message: "must have required property 'owner'",
-              params: { missingProperty: "owner" },
-              schemaPath: "#/required",
+              keyword: "additionalProperties",
+              message: "must NOT have additional properties",
+              params: { additionalProperty: "unknown" },
+              schemaPath: "#/additionalProperties",
             },
           ],
         },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -184,14 +184,15 @@ describe("created data GET routes", () => {
           ],
         },
       ],
-      // [
-      //   "query contains not existing category",
-      //   { owner: "owner", category: "unknown" },
-      //   {
-      //     status: 200,
-      //     response: [],
-      //   },
-      // ],
+      [
+        "query contains not existing category for valid user",
+        testOwner,
+        { category: "unknown" },
+        {
+          status: 200,
+          response: [],
+        },
+      ],
       // [
       //   "query contains existing and matching name and category",
       //   { owner: "owner", name: "games", category: "🎮" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -57,7 +57,7 @@ describe("created data GET routes", () => {
     await testAgent.post("/auth/login").send(mockAuth);
   });
   test("returns correct result for unknown path", async () => {
-    const response = await testClient.get("/data/unknown");
+    const response = await testAgent.get("/data/unknown");
     expect(response.statusCode).toBe(404);
   });
   describe("returns correct result using /data endpoint when", () => {
@@ -252,7 +252,7 @@ describe("created data GET routes", () => {
       //   },
       // ],
     ])("%s", async (_, inputQuery, expected) => {
-      const response = await testClient.get("/data").query(inputQuery);
+      const response = await testAgent.get("/data").query(inputQuery);
       expect(response.statusCode).toBe(expected.status);
       expect(response.body).toStrictEqual(expected.response);
     });

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -1,9 +1,13 @@
 import { DataRouter } from "../../../src/routes/api/data-router.js";
 
 import supertest from "supertest";
+import passport from "passport";
 import express from "express";
+import session from "express-session";
 import path from "path";
 import fs from "fs";
+
+import { Strategy } from "passport-local";
 
 const testDataPath = "./owner/data.json";
 

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -161,28 +161,29 @@ describe("created data GET routes", () => {
           response: [],
         },
       ],
-      // [
-      //   "query contains existing category",
-      //   { owner: "owner", category: "🎮" },
-      //   {
-      //     status: 200,
-      //     response: [
-      //       {
-      //         name: "games",
-      //         category: "🎮",
-      //         items: [
-      //           {
-      //             status: "OK",
-      //             name: "Diablo IV",
-      //             icon: "",
-      //             price: "349.99",
-      //             currency: "PLN",
-      //           },
-      //         ],
-      //       },
-      //     ],
-      //   },
-      // ],
+      [
+        "query contains existing category for valid user",
+        testOwner,
+        { category: "🎮" },
+        {
+          status: 200,
+          response: [
+            {
+              name: "games",
+              category: "🎮",
+              items: [
+                {
+                  status: "OK",
+                  name: "Diablo IV",
+                  icon: "",
+                  price: "349.99",
+                  currency: "PLN",
+                },
+              ],
+            },
+          ],
+        },
+      ],
       // [
       //   "query contains not existing category",
       //   { owner: "owner", category: "unknown" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -243,14 +243,15 @@ describe("created data GET routes", () => {
           response: [],
         },
       ],
-      // [
-      //   "query contains not existing name and category",
-      //   { owner: "owner", name: "unknown", category: "unknown" },
-      //   {
-      //     status: 200,
-      //     response: [],
-      //   },
-      // ],
+      [
+        "query contains not existing name and category",
+        testOwner,
+        { name: "unknown", category: "unknown" },
+        {
+          status: 200,
+          response: [],
+        },
+      ],
     ])("%s", async (_, mockOwner, inputQuery, expected) => {
       // prepare JWT authentication mock
       testAgent.set({ Authorization: `Token JWT-MOCKED-TOKEN` });

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -193,28 +193,29 @@ describe("created data GET routes", () => {
           response: [],
         },
       ],
-      // [
-      //   "query contains existing and matching name and category",
-      //   { owner: "owner", name: "games", category: "🎮" },
-      //   {
-      //     status: 200,
-      //     response: [
-      //       {
-      //         name: "games",
-      //         category: "🎮",
-      //         items: [
-      //           {
-      //             status: "OK",
-      //             name: "Diablo IV",
-      //             icon: "",
-      //             price: "349.99",
-      //             currency: "PLN",
-      //           },
-      //         ],
-      //       },
-      //     ],
-      //   },
-      // ],
+      [
+        "query contains existing and matching name and category for valid user",
+        testOwner,
+        { name: "games", category: "🎮" },
+        {
+          status: 200,
+          response: [
+            {
+              name: "games",
+              category: "🎮",
+              items: [
+                {
+                  status: "OK",
+                  name: "Diablo IV",
+                  icon: "",
+                  price: "349.99",
+                  currency: "PLN",
+                },
+              ],
+            },
+          ],
+        },
+      ],
       // [
       //   "query contains existing but not matching name and category",
       //   { owner: "owner", name: "games", category: "👕" },

--- a/test/routes/api/data-router.test.js
+++ b/test/routes/api/data-router.test.js
@@ -64,179 +64,179 @@ describe("created data GET routes", () => {
           ],
         },
       ],
-      [
-        "query is empty",
-        {},
-        {
-          status: 400,
-          response: [
-            {
-              instancePath: "",
-              keyword: "required",
-              message: "must have required property 'owner'",
-              params: { missingProperty: "owner" },
-              schemaPath: "#/required",
-            },
-          ],
-        },
-      ],
-      [
-        "query contains invalid user",
-        { owner: "invalid" },
-        {
-          status: 400,
-          response: "Invalid data owner provided",
-        },
-      ],
-      [
-        "query contains valid user",
-        { owner: "owner" },
-        {
-          status: 200,
-          response: [
-            {
-              name: "clothes",
-              category: "👕",
-              items: [
-                {
-                  status: "OK",
-                  name: "t-shirt Regular Fit",
-                  icon: "",
-                  price: "29.99",
-                  currency: "PLN",
-                },
-              ],
-            },
-            {
-              name: "games",
-              category: "🎮",
-              items: [
-                {
-                  status: "OK",
-                  name: "Diablo IV",
-                  icon: "",
-                  price: "349.99",
-                  currency: "PLN",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        "query contains existing name",
-        { owner: "owner", name: "clothes" },
-        {
-          status: 200,
-          response: [
-            {
-              name: "clothes",
-              category: "👕",
-              items: [
-                {
-                  status: "OK",
-                  name: "t-shirt Regular Fit",
-                  icon: "",
-                  price: "29.99",
-                  currency: "PLN",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        "query contains not existing name",
-        { owner: "owner", name: "unknown" },
-        {
-          status: 200,
-          response: [],
-        },
-      ],
-      [
-        "query contains existing category",
-        { owner: "owner", category: "🎮" },
-        {
-          status: 200,
-          response: [
-            {
-              name: "games",
-              category: "🎮",
-              items: [
-                {
-                  status: "OK",
-                  name: "Diablo IV",
-                  icon: "",
-                  price: "349.99",
-                  currency: "PLN",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        "query contains not existing category",
-        { owner: "owner", category: "unknown" },
-        {
-          status: 200,
-          response: [],
-        },
-      ],
-      [
-        "query contains existing and matching name and category",
-        { owner: "owner", name: "games", category: "🎮" },
-        {
-          status: 200,
-          response: [
-            {
-              name: "games",
-              category: "🎮",
-              items: [
-                {
-                  status: "OK",
-                  name: "Diablo IV",
-                  icon: "",
-                  price: "349.99",
-                  currency: "PLN",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        "query contains existing but not matching name and category",
-        { owner: "owner", name: "games", category: "👕" },
-        {
-          status: 200,
-          response: [],
-        },
-      ],
-      [
-        "query contains existing name and not existing category",
-        { owner: "owner", name: "games", category: "unknown" },
-        {
-          status: 200,
-          response: [],
-        },
-      ],
-      [
-        "query contains not existing name and existing category",
-        { owner: "owner", name: "unknown", category: "👕" },
-        {
-          status: 200,
-          response: [],
-        },
-      ],
-      [
-        "query contains not existing name and category",
-        { owner: "owner", name: "unknown", category: "unknown" },
-        {
-          status: 200,
-          response: [],
-        },
-      ],
+      // [
+      //   "query is empty",
+      //   {},
+      //   {
+      //     status: 400,
+      //     response: [
+      //       {
+      //         instancePath: "",
+      //         keyword: "required",
+      //         message: "must have required property 'owner'",
+      //         params: { missingProperty: "owner" },
+      //         schemaPath: "#/required",
+      //       },
+      //     ],
+      //   },
+      // ],
+      // [
+      //   "query contains invalid user",
+      //   { owner: "invalid" },
+      //   {
+      //     status: 400,
+      //     response: "Invalid data owner provided",
+      //   },
+      // ],
+      // [
+      //   "query contains valid user",
+      //   { owner: "owner" },
+      //   {
+      //     status: 200,
+      //     response: [
+      //       {
+      //         name: "clothes",
+      //         category: "👕",
+      //         items: [
+      //           {
+      //             status: "OK",
+      //             name: "t-shirt Regular Fit",
+      //             icon: "",
+      //             price: "29.99",
+      //             currency: "PLN",
+      //           },
+      //         ],
+      //       },
+      //       {
+      //         name: "games",
+      //         category: "🎮",
+      //         items: [
+      //           {
+      //             status: "OK",
+      //             name: "Diablo IV",
+      //             icon: "",
+      //             price: "349.99",
+      //             currency: "PLN",
+      //           },
+      //         ],
+      //       },
+      //     ],
+      //   },
+      // ],
+      // [
+      //   "query contains existing name",
+      //   { owner: "owner", name: "clothes" },
+      //   {
+      //     status: 200,
+      //     response: [
+      //       {
+      //         name: "clothes",
+      //         category: "👕",
+      //         items: [
+      //           {
+      //             status: "OK",
+      //             name: "t-shirt Regular Fit",
+      //             icon: "",
+      //             price: "29.99",
+      //             currency: "PLN",
+      //           },
+      //         ],
+      //       },
+      //     ],
+      //   },
+      // ],
+      // [
+      //   "query contains not existing name",
+      //   { owner: "owner", name: "unknown" },
+      //   {
+      //     status: 200,
+      //     response: [],
+      //   },
+      // ],
+      // [
+      //   "query contains existing category",
+      //   { owner: "owner", category: "🎮" },
+      //   {
+      //     status: 200,
+      //     response: [
+      //       {
+      //         name: "games",
+      //         category: "🎮",
+      //         items: [
+      //           {
+      //             status: "OK",
+      //             name: "Diablo IV",
+      //             icon: "",
+      //             price: "349.99",
+      //             currency: "PLN",
+      //           },
+      //         ],
+      //       },
+      //     ],
+      //   },
+      // ],
+      // [
+      //   "query contains not existing category",
+      //   { owner: "owner", category: "unknown" },
+      //   {
+      //     status: 200,
+      //     response: [],
+      //   },
+      // ],
+      // [
+      //   "query contains existing and matching name and category",
+      //   { owner: "owner", name: "games", category: "🎮" },
+      //   {
+      //     status: 200,
+      //     response: [
+      //       {
+      //         name: "games",
+      //         category: "🎮",
+      //         items: [
+      //           {
+      //             status: "OK",
+      //             name: "Diablo IV",
+      //             icon: "",
+      //             price: "349.99",
+      //             currency: "PLN",
+      //           },
+      //         ],
+      //       },
+      //     ],
+      //   },
+      // ],
+      // [
+      //   "query contains existing but not matching name and category",
+      //   { owner: "owner", name: "games", category: "👕" },
+      //   {
+      //     status: 200,
+      //     response: [],
+      //   },
+      // ],
+      // [
+      //   "query contains existing name and not existing category",
+      //   { owner: "owner", name: "games", category: "unknown" },
+      //   {
+      //     status: 200,
+      //     response: [],
+      //   },
+      // ],
+      // [
+      //   "query contains not existing name and existing category",
+      //   { owner: "owner", name: "unknown", category: "👕" },
+      //   {
+      //     status: 200,
+      //     response: [],
+      //   },
+      // ],
+      // [
+      //   "query contains not existing name and category",
+      //   { owner: "owner", name: "unknown", category: "unknown" },
+      //   {
+      //     status: 200,
+      //     response: [],
+      //   },
+      // ],
     ])("%s", async (_, inputQuery, expected) => {
       const response = await testClient.get("/data").query(inputQuery);
       expect(response.statusCode).toBe(expected.status);


### PR DESCRIPTION
This patch fixes #127 
With that change the owner query parameter is not needed because owner will be determined based on JWT.
Due to the above the user will be able to retrieve only its data and not everybody which is more secure.