### PR TITLE
Added different JWT tokens to CI environment

### DIFF
--- a/docs/requests/api-config/add_config-group.bru
+++ b/docs/requests/api-config/add_config-group.bru
@@ -11,7 +11,7 @@ post {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 body:json {

--- a/docs/requests/api-config/add_config-observer.bru
+++ b/docs/requests/api-config/add_config-observer.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 body:json {

--- a/docs/requests/api-config/delete_config-group.bru
+++ b/docs/requests/api-config/delete_config-group.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 body:json {

--- a/docs/requests/api-config/delete_config-observer.bru
+++ b/docs/requests/api-config/delete_config-observer.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 body:json {

--- a/docs/requests/api-config/edit_config-group.bru
+++ b/docs/requests/api-config/edit_config-group.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 body:json {

--- a/docs/requests/api-config/edit_config-observer.bru
+++ b/docs/requests/api-config/edit_config-observer.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 body:json {

--- a/docs/requests/api-config/get_config-all.bru
+++ b/docs/requests/api-config/get_config-all.bru
@@ -11,7 +11,7 @@ get {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 tests {

--- a/docs/requests/api-config/get_config-component.bru
+++ b/docs/requests/api-config/get_config-component.bru
@@ -19,7 +19,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 tests {

--- a/docs/requests/api-config/get_config-empty.bru
+++ b/docs/requests/api-config/get_config-empty.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 tests {

--- a/docs/requests/api-config/get_config-group.bru
+++ b/docs/requests/api-config/get_config-group.bru
@@ -17,7 +17,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 tests {

--- a/docs/requests/api-config/get_config-observer.bru
+++ b/docs/requests/api-config/get_config-observer.bru
@@ -18,7 +18,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{config-token}}
 }
 
 tests {

--- a/docs/requests/api-data/get_data-all.bru
+++ b/docs/requests/api-data/get_data-all.bru
@@ -11,7 +11,7 @@ get {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{data-token}}
 }
 
 tests {

--- a/docs/requests/api-data/get_data-category.bru
+++ b/docs/requests/api-data/get_data-category.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{data-token}}
 }
 
 tests {

--- a/docs/requests/api-data/get_data-empty.bru
+++ b/docs/requests/api-data/get_data-empty.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{data-token}}
 }
 
 tests {

--- a/docs/requests/api-data/get_data-error.bru
+++ b/docs/requests/api-data/get_data-error.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{data-token}}
 }
 
 tests {

--- a/docs/requests/api-data/get_data-name.bru
+++ b/docs/requests/api-data/get_data-name.bru
@@ -15,7 +15,7 @@ params:query {
 }
 
 auth:bearer {
-  token: {{demo-token}}
+  token: {{data-token}}
 }
 
 tests {

--- a/docs/requests/environments/web-scraper.bru
+++ b/docs/requests/environments/web-scraper.bru
@@ -1,3 +1,3 @@
 vars:secret [
-  demo-token
+  config-token
 ]

--- a/docs/requests/environments/web-scraper.bru
+++ b/docs/requests/environments/web-scraper.bru
@@ -1,3 +1,4 @@
 vars:secret [
-  config-token
+  config-token,
+  data-token
 ]


### PR DESCRIPTION
This patch fixes #129 
Now two different tokens (aka users) are used for config and data CI test requests.