### PR TITLE
Initialize demo and CI users when not found in DB

### DIFF
--- a/docs/json/config.json
+++ b/docs/json/config.json
@@ -1,0 +1,93 @@
+{
+  "groups": [
+    {
+      "name": "stocks",
+      "category": "📈",
+      "domain": "https://www.tradingview.com",
+      "observers": [
+        {
+          "name": "McDonald's",
+          "path": "symbols/NYSE-MCD/",
+          "target": "domcontentloaded",
+          "history": "off",
+          "container": "div[class^=symbolRow]",
+          "title": {
+            "interval": "",
+            "selector": "h1",
+            "attribute": "innerHTML",
+            "auxiliary": ""
+          },
+          "image": {
+            "interval": "",
+            "selector": "img[class*=medium]",
+            "attribute": "src",
+            "auxiliary": ""
+          },
+          "price": {
+            "interval": "",
+            "selector": "span[class^=last] span",
+            "attribute": "innerHTML",
+            "auxiliary": "USD"
+          }
+        },
+        {
+          "name": "NVIDIA",
+          "path": "symbols/NASDAQ-NVDA/",
+          "target": "domcontentloaded",
+          "history": "off",
+          "container": "div[class^=symbolRow]",
+          "title": {
+            "interval": "",
+            "selector": "h1",
+            "attribute": "innerHTML",
+            "auxiliary": ""
+          },
+          "image": {
+            "interval": "",
+            "selector": "img[class*=medium]",
+            "attribute": "src",
+            "auxiliary": ""
+          },
+          "price": {
+            "interval": "",
+            "selector": "span[class^=last] span",
+            "attribute": "innerHTML",
+            "auxiliary": "USD"
+          }
+        }
+      ]
+    },
+    {
+      "name": "games",
+      "category": "🎮",
+      "domain": "https://store.steampowered.com/",
+      "observers": [
+        {
+          "name": "Prince of Persia",
+          "path": "app/19980/Prince_of_Persia/",
+          "target": "domcontentloaded",
+          "history": "off",
+          "container": "div.page_content_ctn",
+          "title": {
+            "interval": "",
+            "selector": "div#appHubAppName",
+            "attribute": "innerHTML",
+            "auxiliary": ""
+          },
+          "image": {
+            "interval": "",
+            "selector": "img.game_header_image_full",
+            "attribute": "src",
+            "auxiliary": ""
+          },
+          "price": {
+            "interval": "",
+            "selector": "div.game_purchase_price,div.discount_final_price",
+            "attribute": "innerHTML",
+            "auxiliary": "PLN"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/json/data.json
+++ b/docs/json/data.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "stocks",
+    "category": "📈",
+    "items": [
+      {
+        "status": "OK",
+        "name": "McDonald's Corporation",
+        "icon": "mcdonalds.svg",
+        "price": "292.68",
+        "currency": "USD"
+      },
+      {
+        "status": "OK",
+        "name": "NVIDIA",
+        "icon": "nvidia.svg",
+        "price": "134.70",
+        "currency": "USD"
+      }
+    ]
+  },
+  {
+    "name": "games",
+    "category": "🎮",
+    "items": [
+      {
+        "status": "OK",
+        "name": "Prince of Persia®",
+        "icon": "logo.jpg",
+        "price": "7.98",
+        "currency": "PLN"
+      }
+    ]
+  }
+]

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -97,7 +97,11 @@ export class WebDatabase {
   async #doMaintenance() {
     if (!await this.#hasUserWithEmail(process.env.DEMO_BASE)) {
       // create base demo user (uses demo config from docs/json)
-      const demoUser = {};
+      const demoUser = {
+        name: "demo",
+        email: process.env.DEMO_BASE,
+        password: await bcrypt.hash(process.env.DEMO_PASS, 10),
+      };
       const demoConfig = {};
       await this.#createUserWithConfig(demoUser, demoConfig);
       console.log("Base demo user not found... Created new one!");

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -108,7 +108,11 @@ export class WebDatabase {
     }
     if (!await this.#hasUserWithEmail(process.env.CI_USER)) {
       // create CI user (uses demo config, adds data dir from docs/json)
-      const ciUser = {};
+      const ciUser = {
+        name: "bruno",
+        email: process.env.CI_USER,
+        password: await bcrypt.hash(process.env.CI_PASS, 10),
+      };
       const ciConfig = {};
       await this.#createUserWithConfig(ciUser, ciConfig);
       console.log("CI user not found... Created new one!");

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -113,8 +113,12 @@ export class WebDatabase {
   }
 
   async #createUserWithConfig(user, config) {
-    await ScrapUser.getDatabaseModel().create(user);
-    await ScrapConfig.getDatabaseModel().create(config);
+    const createdUser = await ScrapUser.getDatabaseModel().create(user);
+    const createdConfig = await ScrapConfig.getDatabaseModel().create(config);
+    createdUser.config = createdConfig._id;
+    await createdUser.save();
+    createdConfig.user = createdUser._id;
+    await createdConfig.save();
   }
 
   /**

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -38,8 +38,7 @@ export class WebDatabase {
       };
       await mongoose.connect(dbUrl, dbOptions);
       this.#status.info("Connected to database");
-      const demoUser = await ScrapUser.getDatabaseModel().findOne({ email: "base@demo.com" });
-      if (demoUser == null) {
+      if (false === await this.#hasBaseDemoUser()) {
         console.log("No base demo user. Creating new one...")
       }
       await this.#doMaintenance();
@@ -93,6 +92,10 @@ export class WebDatabase {
    */
   getHistory() {
     return this.#status.getHistory();
+  }
+
+  async #hasBaseDemoUser() {
+    return await ScrapUser.getDatabaseModel().findOne({ email: "base@demo.com" }) != null;
   }
 
   /**

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -135,10 +135,20 @@ export class WebDatabase {
     this.#status.info(`Maintenance summary: ${configsCleaned} configs, ${usersCleaned} demos`);
   }
 
+  /**
+   * Method used to check if a specified email is present in database
+   * @param {String} email The e-mail which presence we want to check
+   * @returns true if specified email is present in database, false otherwise
+   */
   async #hasUserWithEmail(email) {
     return await ScrapUser.getDatabaseModel().findOne({ email: email }) != null;
   }
 
+  /**
+   * Method use to create a new user and config entries in database
+   * @param {Object} user An object representing user which we want to save in database
+   * @param {Object} config An object representing config which we want to save in database
+   */
   async #createUserWithConfig(user, config) {
     const createdUser = await ScrapUser.getDatabaseModel().create(user);
     const createdConfig = await ScrapConfig.getDatabaseModel().create(config);

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -3,6 +3,7 @@ import { ScrapConfig } from "../model/scrap-config.js";
 import { ScrapUser } from "../model/scrap-user.js";
 import { StatusLogger } from "./status-logger.js";
 
+import path from "path";
 import bcrypt from "bcrypt";
 import mongoose from "mongoose";
 
@@ -104,7 +105,8 @@ export class WebDatabase {
         email: process.env.DEMO_BASE,
         password: await bcrypt.hash(process.env.DEMO_PASS, this.#config.authConfig.hashSalt),
       };
-      const demoConfig = {};
+      const configFile = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.config);
+      const demoConfig = JSON.parse(fs.readFileSync(configFile));
       await this.#createUserWithConfig(demoUser, demoConfig);
       console.log("Base demo user not found... Created new one!");
     }

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -97,11 +97,17 @@ export class WebDatabase {
   async #doMaintenance() {
     if (!await this.#hasUserWithEmail(process.env.DEMO_BASE)) {
       // create base demo user (uses demo config from docs/json)
-      console.log("No base demo user. Creating new one...");
+      const demoUser = {};
+      const demoConfig = {};
+      await this.#createUserWithConfig(demoUser, demoConfig);
+      console.log("Base demo user not found... Created new one!");
     }
     if (!await this.#hasUserWithEmail(process.env.CI_USER)) {
       // create CI user (uses demo config, adds data dir from docs/json)
-      console.log("No CI user. Creating new one...");
+      const ciUser = {};
+      const ciConfig = {};
+      await this.#createUserWithConfig(ciUser, ciConfig);
+      console.log("CI user not found... Created new one!");
     }
     const usersCleaned = await this.#cleanDemoUsers();
     const configsCleaned = await this.#cleanUnusedConfigs();

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -123,8 +123,9 @@ export class WebDatabase {
       const ciDataPath = path.join(this.#config.usersDataConfig.path, process.env.CI_USER);
       if (!fs.existsSync(ciDataPath)) {
         fs.mkdirSync(ciDataPath, { recursive: true });
-        const src = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.data);
-        fs.copyFileSync(src, path.join(ciDataPath));
+        const dataSrc = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.data);
+        const dataDst = path.join(ciDataPath, this.#config.jsonDataConfig.data);
+        fs.copyFileSync(dataSrc, dataDst);
       }
       await this.#createUserWithConfig(ciUser, ciConfig);
       console.log("CI user not found... Created new one!");

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -38,6 +38,10 @@ export class WebDatabase {
       };
       await mongoose.connect(dbUrl, dbOptions);
       this.#status.info("Connected to database");
+      const demoUser = await ScrapUser.getDatabaseModel().findOne({ email: "base@demo.com" });
+      if (demoUser == null) {
+        console.log("No base demo user. Creating new one...")
+      }
       await this.#doMaintenance();
       return true;
     } catch (error) {

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -119,6 +119,9 @@ export class WebDatabase {
     return await ScrapUser.getDatabaseModel().findOne({ email: email }) != null;
   }
 
+  /**
+   * Method used to create a new base demo user with config from docs/json
+   */
   async #createBaseDemoUser() {
       const demoUser = {
         name: "demo",
@@ -131,6 +134,10 @@ export class WebDatabase {
       this.#status.info(`Base demo user not found... Created new one!`);
   }
 
+  /**
+   * Method used to create a new CI user with base demo user config from docs/json
+   * Additionally a reference JSON data file is copied from docs/json
+   */
   async #createCiUser() {
       const ciUser = {
         name: "bruno",

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -95,16 +95,21 @@ export class WebDatabase {
    * Method used to perform database maintenance operations after successfull connect
    */
   async #doMaintenance() {
-    if (!await this.#hasBaseDemoUser()) {
-      console.log("No base demo user. Creating new one...")
+    if (!await this.#hasUserWithEmail(process.env.DEMO_BASE)) {
+      // create base demo user (uses demo config from docs/json)
+      console.log("No base demo user. Creating new one...");
+    }
+    if (!await this.#hasUserWithEmail(process.env.CI_USER)) {
+      // create CI user (uses demo config, adds data dir from docs/json)
+      console.log("No CI user. Creating new one...");
     }
     const usersCleaned = await this.#cleanDemoUsers();
     const configsCleaned = await this.#cleanUnusedConfigs();
     this.#status.info(`Maintenance summary: ${configsCleaned} configs, ${usersCleaned} demos`);
   }
 
-  async #hasBaseDemoUser() {
-    return await ScrapUser.getDatabaseModel().findOne({ email: process.env.DEMO_BASE }) != null;
+  async #hasUserWithEmail(email) {
+    return await ScrapUser.getDatabaseModel().findOne({ email: email }) != null;
   }
 
   /**

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -112,6 +112,11 @@ export class WebDatabase {
     return await ScrapUser.getDatabaseModel().findOne({ email: email }) != null;
   }
 
+  async #createUserWithConfig(user, config) {
+    await ScrapUser.getDatabaseModel().create(user);
+    await ScrapConfig.getDatabaseModel().create(config);
+  }
+
   /**
    * Method used to cleanup all demo users (which are just temporary)
    * @returns number of demo session users removed

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -10,16 +10,14 @@ export class WebDatabase {
   static #COMPONENT_NAME = "web-database  ";
 
   #status = undefined;
-  #dbConfig = undefined;
-  #authConfig = undefined;
+  #config = undefined;
 
   /**
    * Creates a new web database from the specified configuration
    * @param {Object} config The object containing database configuration values
    */
   constructor(config) {
-    this.#dbConfig = config.databaseConfig;
-    this.#authConfig = config.authConfig;
+    this.#config = config;
     this.#status = new StatusLogger(WebDatabase.#COMPONENT_NAME, config.minLogLevel);
     this.#status.info("Created");
   }
@@ -29,14 +27,15 @@ export class WebDatabase {
    */
   async start() {
     try {
-      const dbUrl = `mongodb://${this.#dbConfig.url}:${this.#dbConfig.port}`;
+      const dbConfig = this.#config.databaseConfig;
+      const dbUrl = `mongodb://${dbConfig.url}:${dbConfig.port}`;
       const dbOptions = {
-        appName: this.#dbConfig.name,
-        dbName: this.#dbConfig.name,
-        user: this.#dbConfig.user,
-        pass: this.#dbConfig.password,
-        serverSelectionTimeoutMS: this.#dbConfig.timeout,
-        connectTimeoutMS: this.#dbConfig.timeout,
+        appName: dbConfig.name,
+        dbName: dbConfig.name,
+        user: dbConfig.user,
+        pass: dbConfig.password,
+        serverSelectionTimeoutMS: dbConfig.timeout,
+        connectTimeoutMS: dbConfig.timeout,
         family: 4,
       };
       await mongoose.connect(dbUrl, dbOptions);
@@ -103,7 +102,7 @@ export class WebDatabase {
       const demoUser = {
         name: "demo",
         email: process.env.DEMO_BASE,
-        password: await bcrypt.hash(process.env.DEMO_PASS, this.#authConfig.hashSalt),
+        password: await bcrypt.hash(process.env.DEMO_PASS, this.#config.authConfig.hashSalt),
       };
       const demoConfig = {};
       await this.#createUserWithConfig(demoUser, demoConfig);
@@ -114,7 +113,7 @@ export class WebDatabase {
       const ciUser = {
         name: "bruno",
         email: process.env.CI_USER,
-        password: await bcrypt.hash(process.env.CI_PASS, this.#authConfig.hashSalt),
+        password: await bcrypt.hash(process.env.CI_PASS, this.#config.authConfig.hashSalt),
       };
       const ciConfig = {};
       await this.#createUserWithConfig(ciUser, ciConfig);

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -38,7 +38,7 @@ export class WebDatabase {
       };
       await mongoose.connect(dbUrl, dbOptions);
       this.#status.info("Connected to database");
-      if (false === await this.#hasBaseDemoUser()) {
+      if (!await this.#hasBaseDemoUser()) {
         console.log("No base demo user. Creating new one...")
       }
       await this.#doMaintenance();
@@ -95,7 +95,7 @@ export class WebDatabase {
   }
 
   async #hasBaseDemoUser() {
-    return await ScrapUser.getDatabaseModel().findOne({ email: "base@demo.com" }) != null;
+    return await ScrapUser.getDatabaseModel().findOne({ email: process.env.DEMO_BASE }) != null;
   }
 
   /**

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -109,7 +109,7 @@ export class WebDatabase {
       const configFile = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.config);
       const demoConfig = JSON.parse(fs.readFileSync(configFile));
       await this.#createUserWithConfig(demoUser, demoConfig);
-      console.log("Base demo user not found... Created new one!");
+      this.#status.info(`Base demo user not found... Created new one!`);
     }
     if (!await this.#hasUserWithEmail(process.env.CI_USER)) {
       // create CI user (uses demo config, adds data dir from docs/json)
@@ -128,7 +128,7 @@ export class WebDatabase {
         fs.copyFileSync(dataSrc, dataDst);
       }
       await this.#createUserWithConfig(ciUser, ciConfig);
-      console.log("CI user not found... Created new one!");
+      this.#status.info(`CI user not found... Created new one!`);
     }
     const usersCleaned = await this.#cleanDemoUsers();
     const configsCleaned = await this.#cleanUnusedConfigs();

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -104,7 +104,7 @@ export class WebDatabase {
       const demoUser = {
         name: "demo",
         email: process.env.DEMO_BASE,
-        password: await bcrypt.hash(process.env.DEMO_PASS, this.#config.authConfig.hashSalt),
+        password: bcrypt.hashSync(process.env.DEMO_PASS, this.#config.authConfig.hashSalt),
       };
       const configFile = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.config);
       const demoConfig = JSON.parse(fs.readFileSync(configFile));
@@ -116,7 +116,7 @@ export class WebDatabase {
       const ciUser = {
         name: "bruno",
         email: process.env.CI_USER,
-        password: await bcrypt.hash(process.env.CI_PASS, this.#config.authConfig.hashSalt),
+        password: bcrypt.hashSync(process.env.CI_PASS, this.#config.authConfig.hashSalt),
       };
       const configFile = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.config);
       const ciConfig = JSON.parse(fs.readFileSync(configFile));

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -118,7 +118,8 @@ export class WebDatabase {
         email: process.env.CI_USER,
         password: await bcrypt.hash(process.env.CI_PASS, this.#config.authConfig.hashSalt),
       };
-      const ciConfig = {};
+      const configFile = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.config);
+      const ciConfig = JSON.parse(fs.readFileSync(configFile));
       await this.#createUserWithConfig(ciUser, ciConfig);
       console.log("CI user not found... Created new one!");
     }

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -7,10 +7,10 @@ import mongoose from "mongoose";
 
 export class WebDatabase {
   static #COMPONENT_NAME = "web-database  ";
-  static #ENCRYPT_SALT = parseInt(process.env.ENCRYPT_SALT) || 10;
 
   #status = undefined;
   #dbConfig = undefined;
+  #authConfig = undefined;
 
   /**
    * Creates a new web database from the specified configuration
@@ -18,6 +18,7 @@ export class WebDatabase {
    */
   constructor(config) {
     this.#dbConfig = config.databaseConfig;
+    this.#authConfig = config.authConfig;
     this.#status = new StatusLogger(WebDatabase.#COMPONENT_NAME, config.minLogLevel);
     this.#status.info("Created");
   }
@@ -101,7 +102,7 @@ export class WebDatabase {
       const demoUser = {
         name: "demo",
         email: process.env.DEMO_BASE,
-        password: await bcrypt.hash(process.env.DEMO_PASS, WebDatabase.#ENCRYPT_SALT),
+        password: await bcrypt.hash(process.env.DEMO_PASS, this.#authConfig.hashSalt),
       };
       const demoConfig = {};
       await this.#createUserWithConfig(demoUser, demoConfig);
@@ -112,7 +113,7 @@ export class WebDatabase {
       const ciUser = {
         name: "bruno",
         email: process.env.CI_USER,
-        password: await bcrypt.hash(process.env.CI_PASS, WebDatabase.#ENCRYPT_SALT),
+        password: await bcrypt.hash(process.env.CI_PASS, this.#authConfig.hashSalt),
       };
       const ciConfig = {};
       await this.#createUserWithConfig(ciUser, ciConfig);

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -7,6 +7,7 @@ import mongoose from "mongoose";
 
 export class WebDatabase {
   static #COMPONENT_NAME = "web-database  ";
+  static #ENCRYPT_SALT = parseInt(process.env.ENCRYPT_SALT) || 10;
 
   #status = undefined;
   #dbConfig = undefined;
@@ -100,7 +101,7 @@ export class WebDatabase {
       const demoUser = {
         name: "demo",
         email: process.env.DEMO_BASE,
-        password: await bcrypt.hash(process.env.DEMO_PASS, 10),
+        password: await bcrypt.hash(process.env.DEMO_PASS, WebDatabase.#ENCRYPT_SALT),
       };
       const demoConfig = {};
       await this.#createUserWithConfig(demoUser, demoConfig);
@@ -111,7 +112,7 @@ export class WebDatabase {
       const ciUser = {
         name: "bruno",
         email: process.env.CI_USER,
-        password: await bcrypt.hash(process.env.CI_PASS, 10),
+        password: await bcrypt.hash(process.env.CI_PASS, WebDatabase.#ENCRYPT_SALT),
       };
       const ciConfig = {};
       await this.#createUserWithConfig(ciUser, ciConfig);

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -3,6 +3,7 @@ import { ScrapConfig } from "../model/scrap-config.js";
 import { ScrapUser } from "../model/scrap-user.js";
 import { StatusLogger } from "./status-logger.js";
 
+import bcrypt from "bcrypt";
 import mongoose from "mongoose";
 
 export class WebDatabase {

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -120,6 +120,12 @@ export class WebDatabase {
       };
       const configFile = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.config);
       const ciConfig = JSON.parse(fs.readFileSync(configFile));
+      const ciDataPath = path.join(this.#config.usersDataConfig.path, process.env.CI_USER);
+      if (!fs.existsSync(ciDataPath)) {
+        fs.mkdirSync(ciDataPath, { recursive: true });
+        const src = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.data);
+        fs.copyFileSync(src, path.join(ciDataPath));
+      }
       await this.#createUserWithConfig(ciUser, ciConfig);
       console.log("CI user not found... Created new one!");
     }

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -139,15 +139,16 @@ export class WebDatabase {
       };
       const configFile = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.config);
       const ciConfig = JSON.parse(fs.readFileSync(configFile));
+      await this.#createUserWithConfig(ciUser, ciConfig);
+      // copy the reference JSON data file to user directory
       const ciDataPath = path.join(this.#config.usersDataConfig.path, process.env.CI_USER);
       if (!fs.existsSync(ciDataPath)) {
         fs.mkdirSync(ciDataPath, { recursive: true });
         const dataSrc = path.join(this.#config.jsonDataConfig.path, this.#config.jsonDataConfig.data);
         const dataDst = path.join(ciDataPath, this.#config.jsonDataConfig.data);
         fs.copyFileSync(dataSrc, dataDst);
-        await this.#createUserWithConfig(ciUser, ciConfig);
       }
-      this.#status.info(`CI user not found... Created new one!`);
+      this.#status.info(`CI user not found... Created one and copied data file!`);
   }
 
   /**

--- a/src/components/web-database.js
+++ b/src/components/web-database.js
@@ -3,6 +3,7 @@ import { ScrapConfig } from "../model/scrap-config.js";
 import { ScrapUser } from "../model/scrap-user.js";
 import { StatusLogger } from "./status-logger.js";
 
+import fs from "fs";
 import path from "path";
 import bcrypt from "bcrypt";
 import mongoose from "mongoose";

--- a/src/config/app-config.js
+++ b/src/config/app-config.js
@@ -43,6 +43,7 @@ export class AppConfig {
       },
       authConfig: {
         demoMode: new DemoMode(process.env.DEMO_MODE) || DemoMode.DUPLICATE,
+        hashSalt: parseInt(process.env.ENCRYPT_SALT) || 10,
       },
       scraperConfig: {
         loginInterval: 30,

--- a/src/config/app-config.js
+++ b/src/config/app-config.js
@@ -25,6 +25,11 @@ export class AppConfig {
    */
   getConfig() {
     return {
+      jsonDataConfig: {
+        path: path.join(this.#rootDir, "docs", "json"),
+        config: "config.json",
+        data: "data.json",
+      },
       usersDataConfig: {
         path: path.join(this.#rootDir, "users"),
         file: "data.json",

--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -9,7 +9,7 @@ import { Strategy as LocalStategy } from "passport-local";
 import { ExtractJwt, Strategy as JwtStrategy } from "passport-jwt";
 
 export class AuthConfig {
-  static #ENCRYPT_SALT = 10;
+  static #ENCRYPT_SALT = parseInt(process.env.ENCRYPT_SALT) || 10;
 
   #components = undefined;
   #passport = undefined;

--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -9,8 +9,6 @@ import { Strategy as LocalStategy } from "passport-local";
 import { ExtractJwt, Strategy as JwtStrategy } from "passport-jwt";
 
 export class AuthConfig {
-  static #ENCRYPT_SALT = parseInt(process.env.ENCRYPT_SALT) || 10;
-
   #components = undefined;
   #passport = undefined;
   #config = undefined;
@@ -131,7 +129,7 @@ export class AuthConfig {
         const newUser = await ScrapUser.getDatabaseModel().create({
           name: request.body.name,
           email: username,
-          password: await bcrypt.hash(password, AuthConfig.#ENCRYPT_SALT),
+          password: await bcrypt.hash(password, this.#config.hashSalt),
         });
         // user at this point has no config - we must create and link it
         const userConfig = await ScrapConfig.getDatabaseModel().create({ user: newUser._id });

--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -56,7 +56,10 @@ export class AuthConfig {
     };
     const verify = async (jwtPayload, done) => {
       try {
-        const user = await ScrapUser.getDatabaseModel().findById(jwtPayload._id);
+        const user = await ScrapUser.getDatabaseModel().findOne({
+          name: jwtPayload.name,
+          email: jwtPayload.email,
+        });
         if (user) {
           return done(null, user);
         }

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -53,7 +53,9 @@ export class AuthRouter {
       })
     );
     router.get("/token", AccessChecker.canViewContent, (request, response) => {
-      const token = jwt.sign(request.user.toJSON(), process.env.JWT_SECRET);
+      const storedUser = request.user.toJSON();
+      const signedData = { name: storedUser.name, email: storedUser.email, password: storedUser.password };
+      const token = jwt.sign(signedData, process.env.JWT_SECRET);
       return response.status(200).json({ token });
     });
   }

--- a/test/components/web-database.test.js
+++ b/test/components/web-database.test.js
@@ -46,7 +46,7 @@ describe("start() method", () => {
   test("succeeds with valid input data", async () => {
     const mockConfigResult = { countDocuments: () => 1 };
     jest.spyOn(ScrapConfig, "getDatabaseModel").mockImplementation(() => mockConfigResult);
-    const mockUserResult = { countDocuments: () => 1, deleteMany: (_) => ({ deletedCount: 0 }) };
+    const mockUserResult = { findOne: (_) => true, countDocuments: () => 1, deleteMany: (_) => ({ deletedCount: 0 }) };
     jest.spyOn(ScrapUser, "getDatabaseModel").mockImplementation(() => mockUserResult);
     const mongooseConnectSpyOn = jest
       .spyOn(mongoose, "connect")


### PR DESCRIPTION
This patch fixes #130 
At startup the logic checks if base demo or CI users exists in DB. If not then a new set of users is created.
Also I had to update the JWT logic in order to correctly work with demo and CI sessions after reloading.