### PR TITLE
Added scraper configuration via .env

### DIFF
--- a/src/config/app-config.js
+++ b/src/config/app-config.js
@@ -52,7 +52,7 @@ export class AppConfig {
       },
       scraperConfig: {
         loginInterval: parseInt(process.env.SCRAP_INACTIVE_DAYS) || 30,
-        scrapInterval: 30_000,
+        scrapInterval: parseInt(process.env.SCRAP_INTERVAL_SEC) * 1_000 || 30_000,
         defaultTimeout: 15_000,
         timeoutAttempts: 10,
         embeddedBrowser: false,

--- a/src/config/app-config.js
+++ b/src/config/app-config.js
@@ -51,7 +51,7 @@ export class AppConfig {
         hashSalt: parseInt(process.env.ENCRYPT_SALT) || 10,
       },
       scraperConfig: {
-        loginInterval: 30,
+        loginInterval: parseInt(process.env.SCRAP_INACTIVE_DAYS) || 30,
         scrapInterval: 30_000,
         defaultTimeout: 15_000,
         timeoutAttempts: 10,


### PR DESCRIPTION
This patch fixes #141 
Now both scraper login and scrap intervals can be defined via .env file.