### PR TITLE
Fixed scraper stop error when getting history

### DIFF
--- a/src/components/web-scraper.js
+++ b/src/components/web-scraper.js
@@ -254,8 +254,8 @@ export class WebScraper {
       }
     } else {
       // scraper is running in selected intervals
-      if (!currentStatus.startsWith(WebScraper.#RUNNING_STATUS)) {
-        // incorrect state - since it's running then we must stop it
+      if (currentStatus.type === "error") {
+        // incorrect state - since it's running and last message is an error, then we must stop it
         this.stop(sessionUser.email, invalidStateMessage);
       }
     }

--- a/src/components/web-scraper.js
+++ b/src/components/web-scraper.js
@@ -245,10 +245,10 @@ export class WebScraper {
     }
     // all input correct - perform additional checks and then return history
     const invalidStateMessage = "Invalid internal state";
-    const currentStatus = this.#status.getStatus().message;
+    const currentStatus = this.#status.getStatus();
     if (session.id == null) {
       // scraper is NOT running in selected intervals
-      if (currentStatus.startsWith(WebScraper.#RUNNING_STATUS)) {
+      if (currentStatus.message.startsWith(WebScraper.#RUNNING_STATUS)) {
         // incorrect state - update field
         this.#status.error(invalidStateMessage);
       }


### PR DESCRIPTION
This patch fixes #147 
Now when user switches between status and config scraper is not stopped unexpectedly.
It happens only when while reading history last state is error but scraper is stilll running.