### PR TITLE
Added endpoint to receive JWT based on login/pass

### DIFF
--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -89,6 +89,9 @@ export class AuthRouter {
     router.post("/token", AccessChecker.canViewSessionUser, (request, response, next) => {
       this.#passport.authenticate("local-login", { session: false }, (err, user, info) => {
         if (err) return next(err);
+        if (!user) {
+          return response.status(400).json({ error: info.message || "Token retrieval error" });
+        }
         const signedData = { name: user.name, email: user.email, password: user.password };
         const token = jwt.sign(signedData, process.env.JWT_SECRET);
         return response.status(200).json({ token });

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -85,6 +85,13 @@ export class AuthRouter {
       failureFlash: true,
     });
     router.post("/login", AccessChecker.canViewSessionUser, loginCallback);
+    // remote JWT token retrieval
+    router.post("/token", AccessChecker.canViewSessionUser, (request, response, next) => {
+      this.#passport.authenticate("local-login", { session: false }, (err, user, info) => {
+        if (err) return next(err);
+        return response.status(200).json({ message: "Login ok!" });
+      })(request, response, next);
+    });
     // demo functionality login
     const demoCallback = this.#passport.authenticate("local-demo", {
       successRedirect: "/",

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -89,7 +89,9 @@ export class AuthRouter {
     router.post("/token", AccessChecker.canViewSessionUser, (request, response, next) => {
       this.#passport.authenticate("local-login", { session: false }, (err, user, info) => {
         if (err) return next(err);
-        return response.status(200).json({ message: "Login ok!" });
+        const signedData = { name: user.name, email: user.email, password: user.password };
+        const token = jwt.sign(signedData, process.env.JWT_SECRET);
+        return response.status(200).json({ token });
       })(request, response, next);
     });
     // demo functionality login

--- a/test/routes/view/auth-router.test.js
+++ b/test/routes/view/auth-router.test.js
@@ -35,6 +35,7 @@ describe("createRoutes() method", () => {
       { path: "/google/callback", method: "get" },
       { path: "/register", method: "post" },
       { path: "/login", method: "post" },
+      { path: "/token", method: "post" },
       { path: "/demo", method: "post" },
       { path: "/logout", method: "post" },
     ];


### PR DESCRIPTION
This patch fixes #153 
A new endpoint POST /auth/token was added which needs to form-like parameters (email and password) and returns a JWT if the input is correct, or a 400 error otherwise.