### PR TITLE
Added IP to self-hosted images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ### Project-specific ###
 user
+users
 users/*
+upload
+upload/*
 
 ### Node ###
 # Logs

--- a/public/js/controller-component.js
+++ b/public/js/controller-component.js
@@ -168,7 +168,8 @@ export class ComponentsController {
     const fileInput = event.target.previousElementSibling.previousElementSibling;
     ComponentService.addImage(fileInput)
       .then((data) => {
-        CommonController.showToastSuccess(data);
+        event.target.previousElementSibling.setAttribute("url", data.url);
+        CommonController.showToastSuccess(data.message);
       })
       .catch((error) => {
         CommonController.showToastError(error);

--- a/public/js/controller-component.js
+++ b/public/js/controller-component.js
@@ -217,6 +217,9 @@ export class ComponentsController {
         const fileSelected = imgSelect.previousElementSibling.files.length > 0;
         const uploadEnable = !autoEnabled && fileSelected && imgSelect.value !== ComponentsController.#EMPTY_IMAGE_ID;
         this.#updateFieldEnableState([uploadButton], uploadEnable);
+        if (autoEnabled) {
+          imgSelect.value = ComponentsController.#EMPTY_IMAGE_ID;
+        }
       });
     } else {
       throw new Error(`Cannot update card auxiliary enable state`);

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -207,9 +207,14 @@ export class ComponentsView {
     return result;
   }
 
-  static #isUrl(string) {
+  /**
+   * Method used to check if provided string is a valid URL address
+   * @param {String} input The string to be checked
+   * @returns true if input string is a valid URL address, false otherwise
+   */
+  static #isUrl(input) {
     try {
-      new URL(url);
+      new URL(input);
       return true;
     } catch (e) {
       return false;

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -1,4 +1,5 @@
 export class ComponentsView {
+  static #EMPTY_IMAGE_ID = "Select image";
   static COMPONENT_TITLE = 0;
   static COMPONENT_IMAGE = 1;
   static COMPONENT_PRICE = 2;
@@ -22,14 +23,14 @@ export class ComponentsView {
         // we need to check image auxiliary value to correctly determine if empty or not
         const imageButton = componentHtml.querySelector("input.component-image-auxiliary-button");
         let imagePath = imageButton.value;
-        if (imagePath !== "Select image" && !this.#isUrl(imagePath)) {
+        if (imagePath !== ComponentsView.#EMPTY_IMAGE_ID && !this.#isUrl(imagePath)) {
           imagePath = imageButton.getAttribute("url");
         }
         return {
           interval: "",
           selector: componentHtml.querySelector("input.component-image-selector").value,
           attribute: componentHtml.querySelector("input.component-image-attribute").value,
-          auxiliary: imagePath === "Select image" ? "" : imagePath,
+          auxiliary: imagePath === ComponentsView.#EMPTY_IMAGE_ID ? "" : imagePath,
         };
       case ComponentsView.COMPONENT_PRICE:
         return {
@@ -109,7 +110,7 @@ export class ComponentsView {
     const selector = component !== undefined ? component.selector : "";
     const attribute = component !== undefined ? component.attribute : "";
     const auxiliary = component !== undefined ? component.auxiliary : "";
-    const auxButton = "" === auxiliary ? "Select image" : auxiliary;
+    const auxButton = "" === auxiliary ? ComponentsView.#EMPTY_IMAGE_ID : auxiliary;
     return `<div class="component-card">
               <h3 class="card-title">image config</h3>
               <div class="component-content">

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -201,4 +201,13 @@ export class ComponentsView {
       });
     return result;
   }
+
+  static #isUrl(string) {
+    try {
+      new URL(url);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
 }

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -20,12 +20,16 @@ export class ComponentsView {
         };
       case ComponentsView.COMPONENT_IMAGE:
         // we need to check image auxiliary value to correctly determine if empty or not
-        const imageAux = componentHtml.querySelector("input.component-image-auxiliary-button").value;
+        const imageButton = componentHtml.querySelector("input.component-image-auxiliary-button");
+        let imagePath = imageButton.value;
+        if (imagePath !== "Select image" && !this.#isUrl(imagePath)) {
+          imagePath = imageButton.getAttribute("url");
+        }
         return {
           interval: "",
           selector: componentHtml.querySelector("input.component-image-selector").value,
           attribute: componentHtml.querySelector("input.component-image-attribute").value,
-          auxiliary: imageAux === "Select image" ? "" : imageAux,
+          auxiliary: imagePath === "Select image" ? "" : imagePath,
         };
       case ComponentsView.COMPONENT_PRICE:
         return {

--- a/public/js/view-component.js
+++ b/public/js/view-component.js
@@ -110,7 +110,12 @@ export class ComponentsView {
     const selector = component !== undefined ? component.selector : "";
     const attribute = component !== undefined ? component.attribute : "";
     const auxiliary = component !== undefined ? component.auxiliary : "";
-    const auxButton = "" === auxiliary ? ComponentsView.#EMPTY_IMAGE_ID : auxiliary;
+    let imageBtnTags = `value="${ComponentsView.#EMPTY_IMAGE_ID}"`;
+    if ("" !== auxiliary) {
+      imageBtnTags = this.#isUrl(auxiliary)
+        ? `value="${auxiliary.split("/").pop()}" url="${auxiliary}"`
+        : `value="${auxiliary}"`;
+    }
     return `<div class="component-card">
               <h3 class="card-title">image config</h3>
               <div class="component-content">
@@ -127,7 +132,7 @@ export class ComponentsView {
                     <label class="component-image-label">auxiliary:</label>
                     <div class="component-image-file-container">
                       <input type="file" name="auxiliary-file" class="component-image-auxiliary-file" accept="image/*"/>
-                      <input type="button" name="auxiliary-select" class="component-image-auxiliary-button" value="${auxButton}"/>
+                      <input type="button" name="auxiliary-select" class="component-image-auxiliary-button" ${imageBtnTags}/>
                       <input type="submit" name="auxiliary-upload" class="component-image-auxiliary-submit" value="upload"/>
                     </div>
                   </div>

--- a/public/partials/widget.handlebars
+++ b/public/partials/widget.handlebars
@@ -27,7 +27,13 @@
   {{else if (eq type "file")}}
     <div class="{{parent}}-file-container">
       <input type="file" name="{{label}}-file" class="{{parent}}-{{label}}-file" accept="image/*"/>
-      <input type="button" name="{{label}}-select" class="{{parent}}-{{label}}-button" value={{#if (equalsLength value 0)}}"Select image"{{else}}"{{value}}"{{/if}}/>
+      <input type="button" name="{{label}}-select" class="{{parent}}-{{label}}-button"
+        {{#if (equalsLength value 0)}}
+          value="Select image"
+        {{else}}
+          value="{{last (split value "/")}}" url="{{value}}"
+        {{/if}}
+      />
       <input type="button" name="{{label}}-upload" class="{{parent}}-{{label}}-submit" value="upload"/>
     </div>
   {{else}}

--- a/src/components/web-server.js
+++ b/src/components/web-server.js
@@ -96,7 +96,7 @@ export class WebServer {
     server.locals.passport = this.#authConfig.configure();
     // setup web server routes
     const routes = new Map([
-      ["/", new ViewRouter(this.#setupConfig.usersDataConfig.path)],
+      ["/", new ViewRouter(this.#setupConfig.usersDataConfig.upload)],
       ["/auth", new AuthRouter(passport, this.#components)],
       ["/api/v1/data", new DataRouter(this.#setupConfig.usersDataConfig)],
       ["/api/v1/config", new ConfigRouter(this.#components)],

--- a/src/components/web-server.js
+++ b/src/components/web-server.js
@@ -80,6 +80,7 @@ export class WebServer {
     server.set("view engine", "handlebars");
     server.set("views", "./public");
     server.use(express.static("./public"));
+    server.use(express.static("./upload"));
     // setup web server middleware
     server.use(ParamsParser.middleware);
     server.use(RequestLogger.middleware(this.#status));

--- a/src/config/app-config.js
+++ b/src/config/app-config.js
@@ -31,6 +31,7 @@ export class AppConfig {
         data: "data.json",
       },
       usersDataConfig: {
+        upload: path.join(this.#rootDir, "upload"),
         path: path.join(this.#rootDir, "users"),
         file: "data.json",
       },

--- a/src/model/scrap-component.js
+++ b/src/model/scrap-component.js
@@ -83,24 +83,9 @@ export class ScrapComponent {
      */
     const schema = new mongoose.Schema({
       interval: String,
-      selector: {
-        type: String,
-        required: function () {
-          return typeof this.selector === "string" ? false : true;
-        },
-      },
-      attribute: {
-        type: String,
-        required: function () {
-          return typeof this.attribute === "string" ? false : true;
-        },
-      },
-      auxiliary: {
-        type: String,
-        required: function () {
-          return typeof this.auxiliary === "string" ? false : true;
-        },
-      },
+      selector: String,
+      attribute: String,
+      auxiliary: String,
     });
 
     /**

--- a/src/model/scrap-observer.js
+++ b/src/model/scrap-observer.js
@@ -157,8 +157,14 @@ export class ScrapObserver {
         },
       },
       container: String,
-      title: ScrapComponent.getDatabaseSchema(),
-      image: ScrapComponent.getDatabaseSchema(),
+      title: {
+        type: ScrapComponent.getDatabaseSchema(),
+        required: false,
+      },
+      image: {
+        type: ScrapComponent.getDatabaseSchema(),
+        required: false,
+      },
       price: {
         type: ScrapComponent.getDatabaseSchema(),
         required: true,

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -83,7 +83,7 @@ export class ViewRouter {
         fs.mkdirSync(newImageRoot, { recursive: true });
       }
       fileObject.mv(newImagePath);
-      response.status(200).json(`Successfully uploaded image: ${fileObject.name}`);
+      response.status(200).json({ url: `${process.env.SERVER_ADDRESS}${request.user.email}/${fileObject.name}`, message: `Successfully uploaded image: ${fileObject.name}` });
     });
   }
 

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -83,12 +83,10 @@ export class ViewRouter {
         fs.mkdirSync(newImageRoot, { recursive: true });
       }
       fileObject.mv(newImagePath);
-      response
-        .status(200)
-        .json({
-          url: `${process.env.SERVER_ADDRESS}${request.user.email}/${fileObject.name}`,
-          message: `Successfully uploaded image: ${fileObject.name}`,
-        });
+      response.status(200).json({
+        url: `${this.#getServerAddress()}/${request.user.email}/${fileObject.name}`,
+        message: `Successfully uploaded image: ${fileObject.name}`,
+      });
     });
   }
 
@@ -123,6 +121,16 @@ export class ViewRouter {
   #getSupportedStatusTypes() {
     const allLogLevels = [LogLevel.DEBUG, LogLevel.INFO, LogLevel.WARNING, LogLevel.ERROR];
     return `all|${allLogLevels.map((level) => level.description).join("|")}`;
+  }
+
+  #getServerAddress() {
+    if (!process.env.SERVER_ADDRESS) {
+      return `http://localhost:${process.env.SERVER_PORT}`;
+    } else if (process.env.SERVER_ADDRESS.includes("localhost")) {
+      return `${process.env.SERVER_ADDRESS}:${process.env.SERVER_PORT}`;
+    } else {
+      return process.env.SERVER_ADDRESS;
+    }
   }
 
   /**

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -83,7 +83,12 @@ export class ViewRouter {
         fs.mkdirSync(newImageRoot, { recursive: true });
       }
       fileObject.mv(newImagePath);
-      response.status(200).json({ url: `${process.env.SERVER_ADDRESS}${request.user.email}/${fileObject.name}`, message: `Successfully uploaded image: ${fileObject.name}` });
+      response
+        .status(200)
+        .json({
+          url: `${process.env.SERVER_ADDRESS}${request.user.email}/${fileObject.name}`,
+          message: `Successfully uploaded image: ${fileObject.name}`,
+        });
     });
   }
 

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -123,6 +123,10 @@ export class ViewRouter {
     return `all|${allLogLevels.map((level) => level.description).join("|")}`;
   }
 
+  /**
+   * Method used to retrieve scraper server URL address (URI + optional port)
+   * @returns string containing scraper address
+   */
   #getServerAddress() {
     if (!process.env.SERVER_ADDRESS) {
       return `http://localhost:${process.env.SERVER_PORT}`;

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -8,14 +8,14 @@ import path from "path";
 import fs from "fs";
 
 export class ViewRouter {
-  #dataFilePath = undefined;
+  #uploadPath = undefined;
 
   /**
    * Creates a new view router for displaying scraper config settings
-   * @param {String} dataFile The path to the data file
+   * @param {String} uploadPath The path to the upload directory
    */
-  constructor(dataFile) {
-    this.#dataFilePath = dataFile;
+  constructor(uploadPath) {
+    this.#uploadPath = uploadPath;
   }
 
   /**
@@ -77,7 +77,7 @@ export class ViewRouter {
       if (!imageMimeRegex.test(fileObject.mimetype)) {
         return response.status(400).json("Provided file is NOT an image file");
       }
-      const newImagePath = path.join(this.#dataFilePath, request.user.email, "images", fileObject.name);
+      const newImagePath = path.join(this.#uploadPath, request.user.email, fileObject.name);
       const newImageRoot = path.dirname(newImagePath);
       if (!fs.existsSync(newImageRoot)) {
         fs.mkdirSync(newImageRoot, { recursive: true });

--- a/test/config/app-config.test.js
+++ b/test/config/app-config.test.js
@@ -12,6 +12,7 @@ describe("getConfig", () => {
     expect(testConfig.jsonDataConfig.config).toMatch("config.json");
     expect(testConfig.jsonDataConfig.data).toMatch("data.json");
     expect(testConfig.usersDataConfig).not.toBe(null);
+    expect(testConfig.usersDataConfig.upload).toMatch("web-scraper" + path.sep + "upload");
     expect(testConfig.usersDataConfig.path).toMatch("web-scraper" + path.sep + "users");
     expect(testConfig.usersDataConfig.file).toMatch("data.json");
     expect(testConfig.minLogLevel).toBe(LogLevel.INFO);

--- a/test/model/scrap-component.test.js
+++ b/test/model/scrap-component.test.js
@@ -120,27 +120,15 @@ describe("getDatabaseSchema", () => {
     describe("with correct logic", () => {
       test("for selector field", () => {
         const requiredSelector = paths.selector.options.required;
-        expect(typeof requiredSelector).toBe("function");
-        const contextWithSelector = { selector: "abc" };
-        const contextWithoutSelector = { selector: undefined };
-        expect(requiredSelector.call(contextWithSelector)).toBe(false);
-        expect(requiredSelector.call(contextWithoutSelector)).toBe(true);
+        expect(typeof requiredSelector).toBe("undefined");
       });
       test("for attribute field", () => {
         const requiredAttribute = paths.attribute.options.required;
-        expect(typeof requiredAttribute).toBe("function");
-        const contextWithAttribute = { attribute: "abc" };
-        const contextWithoutAttribute = { attribute: undefined };
-        expect(requiredAttribute.call(contextWithAttribute)).toBe(false);
-        expect(requiredAttribute.call(contextWithoutAttribute)).toBe(true);
+        expect(typeof requiredAttribute).toBe("undefined");
       });
       test("for auxiliary field", () => {
         const requiredAuxiliary = paths.auxiliary.options.required;
-        expect(typeof requiredAuxiliary).toBe("function");
-        const contextWithAuxiliary = { auxiliary: "abc" };
-        const contextWithoutAuxiliary = { auxiliary: undefined };
-        expect(requiredAuxiliary.call(contextWithAuxiliary)).toBe(false);
-        expect(requiredAuxiliary.call(contextWithoutAuxiliary)).toBe(true);
+        expect(typeof requiredAuxiliary).toBe("undefined");
       });
     });
   });

--- a/test/routes/view/view-router.test.js
+++ b/test/routes/view/view-router.test.js
@@ -148,7 +148,10 @@ describe("created view POST routes", () => {
       jest.spyOn(fs, "existsSync").mockImplementation((_) => false);
       const response = await testAgent.post("/view/image").attach('auxiliary-file', testImagePath);
       expect(response.statusCode).toBe(200);
-      expect(response.body).toBe("Successfully uploaded image: testfile.png");
+      expect(response.body).toStrictEqual({
+        message: "Successfully uploaded image: testfile.png",
+        url: "http://localhost:undefined/test@mail.c/testfile.png",
+      });
       removeDataFile(testImagePath);
     });
   });

--- a/test/routes/view/view-router.test.js
+++ b/test/routes/view/view-router.test.js
@@ -133,20 +133,20 @@ describe("created view POST routes", () => {
       expect(response.body).toBe("No file provided");
     });
     test("with a non-image file provided", async () => {
-      const testDataPath = path.join('.', 'testfile.json');
+      const testDataPath = path.join(".", "testfile.json");
       createDataFile(testDataPath);
-      const response = await testAgent.post("/view/image").attach('auxiliary-file', testDataPath);
+      const response = await testAgent.post("/view/image").attach("auxiliary-file", testDataPath);
       expect(response.statusCode).toBe(400);
       expect(response.body).toBe("Provided file is NOT an image file");
       removeDataFile(testDataPath);
     });
     test("with an image file provided", async () => {
-      const testImagePath = path.join('.', 'testfile.png');
+      const testImagePath = path.join(".", "testfile.png");
       createDataFile(testImagePath);
       jest.spyOn(path, "join").mockImplementation((_) => testImagePath);
       jest.spyOn(fs, "mkdirSync").mockImplementation((_) => {});
       jest.spyOn(fs, "existsSync").mockImplementation((_) => false);
-      const response = await testAgent.post("/view/image").attach('auxiliary-file', testImagePath);
+      const response = await testAgent.post("/view/image").attach("auxiliary-file", testImagePath);
       expect(response.statusCode).toBe(200);
       expect(response.body).toStrictEqual({
         message: "Successfully uploaded image: testfile.png",
@@ -161,13 +161,15 @@ function createMockAuthRouter() {
   const router = express.Router();
   const configId = 123;
   const userName = "test-name";
-  const userMail = "test@mail.c"
+  const userMail = "test@mail.c";
   // configure mocked login logic
   const options = { usernameField: "mail", passwordField: "pass" };
   const verify = (_user, _pass, done) => done(null, { id: 1, config: configId, name: userName });
   passport.use("mock-login", new Strategy(options, verify));
   passport.serializeUser((user, done) => done(null, user.id));
-  passport.deserializeUser((userId, done) => done(null, { id: userId, config: configId, name: userName, email: userMail }));
+  passport.deserializeUser((userId, done) =>
+    done(null, { id: userId, config: configId, name: userName, email: userMail })
+  );
   // use passport mock login in tests
   router.post("/login", passport.authenticate("mock-login"));
   return router;


### PR DESCRIPTION
This patch fixes #158 
Now all self-hosted images are available from the web-scraper service and their location contains scraper address. Also some other bugfixes were corrected and DB schema adjusted to work correctly with auto/manual image selector.