### PR TITLE
Added challenge passphrase to JWT token retrieval

### DIFF
--- a/src/components/web-server.js
+++ b/src/components/web-server.js
@@ -97,7 +97,7 @@ export class WebServer {
     // setup web server routes
     const routes = new Map([
       ["/", new ViewRouter(this.#setupConfig.usersDataConfig.upload)],
-      ["/auth", new AuthRouter(passport, this.#components)],
+      ["/auth", new AuthRouter(passport, this.#components, this.#setupConfig.authConfig)],
       ["/api/v1/data", new DataRouter(this.#setupConfig.usersDataConfig)],
       ["/api/v1/config", new ConfigRouter(this.#components)],
       ["/api/v1/status", new StatusRouter(this.#status, this.#components)],

--- a/src/model/scrap-user.js
+++ b/src/model/scrap-user.js
@@ -37,6 +37,7 @@ export class ScrapUser {
         type: String,
         required: true,
       },
+      challenge: String,
       lastLogin: Date,
       hostUser: mongoose.Types.ObjectId,
       config: {

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -15,6 +15,8 @@ export class AuthRouter {
   /**
    * Creates a new auth router for managing user authentication and authorization
    * @param {Object} passport The object controlling user sing-up and sing-in process
+   * @param {Array} components An array with web components to be used in logout action
+   * @param {Object} config Authentication configuration for hashing secret values
    */
   constructor(passport, components, config) {
     this.#components = components;

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -5,6 +5,7 @@ import { ScrapUser } from "../../model/scrap-user.js";
 
 import jwt from "jsonwebtoken";
 import express from "express";
+import bcrypt from "bcrypt";
 
 export class AuthRouter {
   #components = undefined;
@@ -98,7 +99,8 @@ export class AuthRouter {
         }
         const signedData = { name: user.name, email: user.email, password: user.password };
         const token = jwt.sign(signedData, process.env.JWT_SECRET);
-        return response.status(200).json({ token });
+        const challenge = bcrypt.hashSync(request.connection.remoteAddress, 10);
+        return response.status(200).json({ token, challenge });
       })(request, response, next);
     });
     // demo functionality login

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -6,6 +6,7 @@ import { ScrapUser } from "../../model/scrap-user.js";
 import jwt from "jsonwebtoken";
 import express from "express";
 import bcrypt from "bcrypt";
+import { ChallengeUtils } from "../../utils/challenge-utils.js";
 
 export class AuthRouter {
   #components = undefined;
@@ -107,7 +108,10 @@ export class AuthRouter {
         if (!dbUser) {
           return response.status(400).json({ error: "Token retrieval error" });
         }
-        const challenge = bcrypt.hashSync(request.connection.remoteAddress, this.#config.hashSalt);
+        const challenge = bcrypt.hashSync(
+          ChallengeUtils.generate(user.name, request.connection.remoteAddress, user.email),
+          this.#config.hashSalt
+        );
         dbUser.challenge = challenge;
         await dbUser.save();
         return response.status(200).json({ token, challenge });

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -10,14 +10,16 @@ import bcrypt from "bcrypt";
 export class AuthRouter {
   #components = undefined;
   #passport = undefined;
+  #config = undefined;
 
   /**
    * Creates a new auth router for managing user authentication and authorization
    * @param {Object} passport The object controlling user sing-up and sing-in process
    */
-  constructor(passport, components) {
+  constructor(passport, components, config) {
     this.#components = components;
     this.#passport = passport;
+    this.#config = config;
   }
 
   /**
@@ -99,7 +101,7 @@ export class AuthRouter {
         }
         const signedData = { name: user.name, email: user.email, password: user.password };
         const token = jwt.sign(signedData, process.env.JWT_SECRET);
-        const challenge = bcrypt.hashSync(request.connection.remoteAddress, 10);
+        const challenge = bcrypt.hashSync(request.connection.remoteAddress, this.#config.hashSalt);
         return response.status(200).json({ token, challenge });
       })(request, response, next);
     });

--- a/src/utils/challenge-utils.js
+++ b/src/utils/challenge-utils.js
@@ -1,0 +1,5 @@
+export class ChallengeUtils {
+  static generate(...inputs) {
+    return inputs.join("|");
+  }
+}

--- a/src/utils/challenge-utils.js
+++ b/src/utils/challenge-utils.js
@@ -1,7 +1,7 @@
 export class ChallengeUtils {
   /**
    * Method used to generate challenge phrase
-   * @param  {Array} inputs Array of inputs which form challenge
+   * @param {Array} inputs Array of inputs which form challenge
    * @returns String containing generated challenge phrase
    */
   static generate(...inputs) {
@@ -9,6 +9,11 @@ export class ChallengeUtils {
     return process.env.CHALLENGE_PREFIX + shuffled;
   }
 
+  /**
+   * Method used to shuffle input string
+   * @param {String} input The string which contents we want to shuffle
+   * @returns shuffled string
+   */
   static #shuffle(input) {
     let chars = input.split("");
     for (let i = 0; i < chars.length - 1; i += 2) {

--- a/src/utils/challenge-utils.js
+++ b/src/utils/challenge-utils.js
@@ -5,6 +5,14 @@ export class ChallengeUtils {
    * @returns String containing generated challenge phrase
    */
   static generate(...inputs) {
-    return inputs.join(process.env.CHALLENGE_JOIN);
+    return inputs.map((input) => this.#shuffle(input)).join(process.env.CHALLENGE_JOIN);
+  }
+
+  static #shuffle(input) {
+    let chars = input.split("");
+    for (let i = 0; i < chars.length - 1; i += 2) {
+      [chars[i], chars[i + 1]] = [chars[i + 1], chars[i]];
+    }
+    return chars.reverse().join("");
   }
 }

--- a/src/utils/challenge-utils.js
+++ b/src/utils/challenge-utils.js
@@ -5,7 +5,8 @@ export class ChallengeUtils {
    * @returns String containing generated challenge phrase
    */
   static generate(...inputs) {
-    return inputs.map((input) => this.#shuffle(input)).join(process.env.CHALLENGE_JOIN);
+    const shuffled = inputs.map((input) => this.#shuffle(input)).join(process.env.CHALLENGE_JOIN);
+    return process.env.CHALLENGE_PREFIX + shuffled;
   }
 
   static #shuffle(input) {

--- a/src/utils/challenge-utils.js
+++ b/src/utils/challenge-utils.js
@@ -1,4 +1,9 @@
 export class ChallengeUtils {
+  /**
+   * Method used to generate challenge phrase
+   * @param  {Array} inputs Array of inputs which form challenge
+   * @returns String containing generated challenge phrase
+   */
   static generate(...inputs) {
     return inputs.join(process.env.CHALLENGE_JOIN);
   }

--- a/src/utils/challenge-utils.js
+++ b/src/utils/challenge-utils.js
@@ -1,5 +1,5 @@
 export class ChallengeUtils {
   static generate(...inputs) {
-    return inputs.join("|");
+    return inputs.join(process.env.CHALLENGE_JOIN);
   }
 }


### PR DESCRIPTION
This patch fixes #162 
Now when an external user sends a token POST request a new challenge is received (when mail and pass are correct) which is then used for external login and edition.