### PR TITLE
Added export and import scraper configuration feature

### DIFF
--- a/public/css/page.css
+++ b/public/css/page.css
@@ -92,6 +92,10 @@ div.widget {
   }
 }
 
+.half {
+  width: 50%;
+}
+
 .fill {
   width: 100%;
 }

--- a/public/css/page.css
+++ b/public/css/page.css
@@ -319,7 +319,12 @@ footer#main-footer i#show-github {
 
 div#status-preview i#show-dashboard {
   color: white;
-  margin-left: 5px;
+  margin-left: 3px;
+}
+
+div#status-preview i#show-settings {
+  color: white;
+  margin-left: 0px;
 }
 
 div#status-preview i#status-web-database {

--- a/public/css/page.css
+++ b/public/css/page.css
@@ -310,7 +310,7 @@ footer#main-footer div#status-preview.preview {
 
 footer#main-footer div#status-preview.expanded {
   transition: width 0.5s ease;
-  width: 115px;
+  width: 140px;
 }
 
 footer#main-footer i#show-github {

--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -1,0 +1,31 @@
+section.settings-dashboard {
+  color: black;
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-direction: column;
+  margin: 0.1rem;
+  height: calc(100% - 4.5rem);
+}
+
+@media screen and (min-width: 980px) {
+  section.settings-dashboard {
+    margin: 1rem 0.75rem;
+  }
+}
+
+div.settings-options {
+  width: 100%;
+  display: none;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+@media screen and (min-width: 500px) {
+  div.settings-options {
+    display: flex;
+    flex-wrap: wrap;
+  }
+}

--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -29,3 +29,49 @@ div.settings-options {
     flex-wrap: wrap;
   }
 }
+
+.config-file-container {
+  display: flex;
+  width: 100%;
+}
+
+.config-import-file {
+  display: none;
+}
+
+.config-import-button {
+  cursor: pointer;
+  width: 100%;
+  height: 1.8rem;
+  font-size: 0.8rem;
+  color: black;
+  background-color: white;
+  border-radius: 5px;
+  border: 1px solid black;
+  box-shadow: 2px 2px 5px black;
+}
+
+.config-import-apply {
+  cursor: pointer;
+  width: 25%;
+  height: 1.8rem;
+  font-size: 0.8rem;
+  color: black;
+  background-color: white;
+  border-radius: 5px;
+  border: 1px solid black;
+  box-shadow: 2px 2px 5px black;
+  margin-left: 5px;
+}
+
+.config-export-apply {
+  cursor: pointer;
+  width: 100%;
+  height: 1.8rem;
+  font-size: 0.8rem;
+  color: black;
+  background-color: white;
+  border-radius: 5px;
+  border: 1px solid black;
+  box-shadow: 2px 2px 5px black;
+}

--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -1,7 +1,7 @@
 section.settings-dashboard {
   color: black;
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: flex-start;
   flex-direction: column;
   margin: 0.1rem;
@@ -18,10 +18,11 @@ div.settings-options {
   width: 100%;
   display: none;
   align-items: center;
+  align-content: center;
   justify-content: flex-start;
   flex-wrap: wrap;
   gap: 1rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 5rem;
 }
 
 @media screen and (min-width: 500px) {

--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -20,6 +20,7 @@ div.settings-options {
   align-items: center;
   justify-content: flex-start;
   flex-wrap: wrap;
+  gap: 1rem;
   margin-bottom: 0.5rem;
 }
 
@@ -27,6 +28,7 @@ div.settings-options {
   div.settings-options {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
   }
 }
 

--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -48,9 +48,14 @@ div.settings-options {
   font-size: 0.8rem;
   color: black;
   background-color: white;
+  transition: background-color 0.25s ease;
   border-radius: 5px;
   border: 1px solid black;
   box-shadow: 2px 2px 5px black;
+}
+
+.config-import-button:hover {
+  background-color: rgb(190, 180, 255);
 }
 
 .config-import-apply {
@@ -60,10 +65,21 @@ div.settings-options {
   font-size: 0.8rem;
   color: black;
   background-color: white;
+  transition: background-color 0.25s ease;
   border-radius: 5px;
   border: 1px solid black;
   box-shadow: 2px 2px 5px black;
-  margin-left: 5px;
+  margin-left: 0.75rem;
+}
+
+.config-import-apply:hover {
+  background-color: limegreen;
+}
+
+.config-import-apply[disabled] {
+  cursor: default;
+  pointer-events: none;
+  opacity: 75%;
 }
 
 .config-export-apply {
@@ -73,7 +89,12 @@ div.settings-options {
   font-size: 0.8rem;
   color: black;
   background-color: white;
+  transition: background-color 0.25s ease;
   border-radius: 5px;
   border: 1px solid black;
   box-shadow: 2px 2px 5px black;
+}
+
+.config-export-apply:hover {
+  background-color: rgb(190, 180, 255);
 }

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -16,7 +16,7 @@ export class SettingsController {
 
   #bindListeners() {
     document.querySelectorAll("input.config-export-apply").forEach((button) => {
-      button.addEventListener("click", this.#exportConfigToFileHandler);
+      button.addEventListener("click", (_) => this.#exportConfigToFileHandler());
     });
     document.querySelectorAll("input.config-import-file").forEach((selector) => {
       selector.addEventListener("change", this.#changeImportConfigFileHandler);

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -61,6 +61,22 @@ export class SettingsController {
 
   async #getConfigFileBlob() {
     const config = await SettingsService.getConfig();
-    return new Blob([config], { type: "application/json" });
+    // remove unwanted DB properties (_id, __v, etc.)
+    const raw = this.#propsOmitter(config, ["_id", "__v"]);
+    return new Blob([raw], { type: "application/json" });
+  }
+
+  #propsOmitter(obj, keysToOmit) {
+    if (Array.isArray(obj)) {
+      return obj.map((item) => this.#propsOmitter(item, keysToOmit));
+    } else if (obj !== null && typeof obj === "object") {
+      return Object.keys(obj).reduce((acc, key) => {
+        if (!keysToOmit.includes(key)) {
+          acc[key] = this.#propsOmitter(obj[key], keysToOmit);
+        }
+        return acc;
+      }, {});
+    }
+    return obj;
   }
 }

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -1,5 +1,13 @@
 export class SettingsController {
   constructor() {
+    this.#initController();
+  }
+
+  #initController() {
+    const importApply = document.querySelector("input.config-import-apply");
+    if (importApply) {
+      importApply.disabled = true;
+    }
     this.#bindListeners();
   }
 

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -1,3 +1,6 @@
+import { CommonController } from "./controller-common.js";
+import { SettingsService } from "./service-settings.js";
+
 export class SettingsController {
   constructor() {
     this.#initController();
@@ -22,7 +25,7 @@ export class SettingsController {
       button.addEventListener("click", this.#selectImportConfigFileHandler);
     });
     document.querySelectorAll("input.config-import-apply").forEach((button) => {
-      button.addEventListener("click", console.log("IMPORT APPLIED"));
+      button.addEventListener("click", this.#applyImportConfigFileHandler);
     });
   }
 
@@ -37,5 +40,12 @@ export class SettingsController {
   #selectImportConfigFileHandler(event) {
     event.target.previousElementSibling.click();
     event.stopPropagation();
+  }
+
+  #applyImportConfigFileHandler(event) {
+    const fileInput = event.target.previousElementSibling.previousElementSibling;
+    SettingsService.importConfig(fileInput)
+      .then((data) => CommonController.showToastSuccess(data))
+      .catch((error) => CommonController.showToastError(error));
   }
 }

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -2,10 +2,16 @@ import { CommonController } from "./controller-common.js";
 import { SettingsService } from "./service-settings.js";
 
 export class SettingsController {
+  /**
+   * Creates settings controller which initializes data and binds all listeners
+   */
   constructor() {
     this.#initController();
   }
 
+  /**
+   * Method to initialize controller and set starting UI values, bind listeners, etc.
+   */
   #initController() {
     const importApply = document.querySelector("input.config-import-apply");
     if (importApply) {
@@ -14,6 +20,9 @@ export class SettingsController {
     this.#bindListeners();
   }
 
+  /**
+   * Method used to bind all UI widget listeners with controller methods
+   */
   #bindListeners() {
     document.querySelectorAll("input.config-export-apply").forEach((button) => {
       button.addEventListener("click", (_) => this.#exportConfigToFileHandler());
@@ -29,6 +38,10 @@ export class SettingsController {
     });
   }
 
+  /**
+   * Handler controlling export configuration button behavior
+   * @note: This method shows save dialog and saves current user's config to JSON file
+   */
   async #exportConfigToFileHandler() {
     const configBlob = await this.#getConfigFileBlob();
     const fileHandle = await window.showSaveFilePicker({
@@ -39,6 +52,10 @@ export class SettingsController {
     await writeFileStream.close();
   }
 
+  /**
+   * Handler controlling (invisible for the user) file selector input behavior
+   * @param {Event} event The inner data initialized with input event
+   */
   #changeImportConfigFileHandler(event) {
     if (event.target.files[0]) {
       const fileButton = event.target.nextElementSibling;
@@ -47,11 +64,20 @@ export class SettingsController {
     }
   }
 
+  /**
+   * Handler controlling (visible for the user) import config file button behavior
+   * @note: Underneath it invokes file selector behavior by simulating click/change action
+   * @param {Event} event The inner data initialized with button event
+   */
   #selectImportConfigFileHandler(event) {
     event.target.previousElementSibling.click();
     event.stopPropagation();
   }
 
+  /**
+   * Handler controlling import config file apply button behavior
+   * @param {Event} event The inner data initialized with button event
+   */
   #applyImportConfigFileHandler(event) {
     const fileInput = event.target.previousElementSibling.previousElementSibling;
     SettingsService.importConfig(fileInput)
@@ -59,6 +85,10 @@ export class SettingsController {
       .catch((error) => CommonController.showToastError(error));
   }
 
+  /**
+   * Method used to retrieve the blob with scraper configuration content
+   * @returns JSON blob containing scraper configuration to be exported
+   */
   async #getConfigFileBlob() {
     const config = await SettingsService.getConfig();
     // remove unwanted DB properties (_id, __v, etc.)
@@ -66,6 +96,12 @@ export class SettingsController {
     return new Blob([JSON.stringify(raw)], { type: "application/json" });
   }
 
+  /**
+   * Method used to remove the specified keys from the input object
+   * @param {Object} obj The object from which we want to remove the specified keys
+   * @param {Array} keysToOmit The array with keys to be removed from the object
+   * @returns The object without the keys specified in the input
+   */
   #propsOmitter(obj, keysToOmit) {
     if (Array.isArray(obj)) {
       return obj.map((item) => this.#propsOmitter(item, keysToOmit));

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -8,13 +8,26 @@ export class SettingsController {
       button.addEventListener("click", console.log("EXPORT APPLIED"));
     });
     document.querySelectorAll("input.config-import-file").forEach((selector) => {
-      selector.addEventListener("change", console.log("FILE CHANGED"));
+      selector.addEventListener("change", this.#changeImportConfigFileHandler);
     });
     document.querySelectorAll("input.config-import-button").forEach((button) => {
-      button.addEventListener("click", console.log("FILE INVOKED"));
+      button.addEventListener("click", this.#selectImportConfigFileHandler);
     });
     document.querySelectorAll("input.config-import-apply").forEach((button) => {
       button.addEventListener("click", console.log("IMPORT APPLIED"));
     });
+  }
+
+  #changeImportConfigFileHandler(event) {
+    if (event.target.files[0]) {
+      const fileButton = event.target.nextElementSibling;
+      fileButton.value = event.target.files[0].name;
+      event.target.nextElementSibling.nextElementSibling.disabled = false;
+    }
+  }
+
+  #selectImportConfigFileHandler(event) {
+    event.target.previousElementSibling.click();
+    event.stopPropagation();
   }
 }

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -63,7 +63,7 @@ export class SettingsController {
     const config = await SettingsService.getConfig();
     // remove unwanted DB properties (_id, __v, etc.)
     const raw = this.#propsOmitter(config, ["_id", "__v"]);
-    return new Blob([raw], { type: "application/json" });
+    return new Blob([JSON.stringify(raw)], { type: "application/json" });
   }
 
   #propsOmitter(obj, keysToOmit) {

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -30,8 +30,7 @@ export class SettingsController {
   }
 
   async #exportConfigToFileHandler() {
-    const config = await SettingsService.getConfig();
-    const configBlob = new Blob([config], { type: "application/json" });
+    const configBlob = await this.#getConfigFileBlob();
     const fileHandle = await window.showSaveFilePicker({
       types: [{ accept: { "application/json": [".json"] } }],
     });
@@ -58,5 +57,10 @@ export class SettingsController {
     SettingsService.importConfig(fileInput)
       .then((data) => CommonController.showToastSuccess(data))
       .catch((error) => CommonController.showToastError(error));
+  }
+
+  async #getConfigFileBlob() {
+    const config = await SettingsService.getConfig();
+    return new Blob([config], { type: "application/json" });
   }
 }

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -16,7 +16,7 @@ export class SettingsController {
 
   #bindListeners() {
     document.querySelectorAll("input.config-export-apply").forEach((button) => {
-      button.addEventListener("click", console.log("EXPORT APPLIED"));
+      button.addEventListener("click", this.#exportConfigToFileHandler);
     });
     document.querySelectorAll("input.config-import-file").forEach((selector) => {
       selector.addEventListener("change", this.#changeImportConfigFileHandler);
@@ -27,6 +27,17 @@ export class SettingsController {
     document.querySelectorAll("input.config-import-apply").forEach((button) => {
       button.addEventListener("click", this.#applyImportConfigFileHandler);
     });
+  }
+
+  async #exportConfigToFileHandler() {
+    const config = await SettingsService.getConfig();
+    const configBlob = new Blob([config], { type: "application/json" });
+    const fileHandle = await window.showSaveFilePicker({
+      types: [{ accept: { "application/json": [".json"] } }],
+    });
+    const writeFileStream = await fileHandle.createWritable();
+    await writeFileStream.write(configBlob);
+    await writeFileStream.close();
   }
 
   #changeImportConfigFileHandler(event) {

--- a/public/js/controller-settings.js
+++ b/public/js/controller-settings.js
@@ -1,0 +1,20 @@
+export class SettingsController {
+  constructor() {
+    this.#bindListeners();
+  }
+
+  #bindListeners() {
+    document.querySelectorAll("input.config-export-apply").forEach((button) => {
+      button.addEventListener("click", console.log("EXPORT APPLIED"));
+    });
+    document.querySelectorAll("input.config-import-file").forEach((selector) => {
+      selector.addEventListener("change", console.log("FILE CHANGED"));
+    });
+    document.querySelectorAll("input.config-import-button").forEach((button) => {
+      button.addEventListener("click", console.log("FILE INVOKED"));
+    });
+    document.querySelectorAll("input.config-import-apply").forEach((button) => {
+      button.addEventListener("click", console.log("IMPORT APPLIED"));
+    });
+  }
+}

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3,6 +3,7 @@ import { ComponentsController } from "./controller-component.js";
 import { ObserversController } from "./controller-observer.js";
 import { GroupsController } from "./controller-group.js";
 import { StatusController } from "./controller-status.js";
+import { SettingsController } from "./controller-settings.js";
 
 main();
 
@@ -20,6 +21,11 @@ function main() {
   // start current status controller and monitor components
   const statusController = new StatusController();
   statusController.start();
+  // initialize settings controller if needed
+  const settingsDashboard = document.getElementsByClassName("settings-dashboard");
+  if (settingsDashboard) {
+    new SettingsController();
+  }
   // add user logout button handler cleaning JWT
   const logoutButton = document.getElementById("user-logout");
   if (logoutButton) {

--- a/public/js/service-settings.js
+++ b/public/js/service-settings.js
@@ -1,6 +1,10 @@
 import { CommonService } from "./service-common.js";
 
 export class SettingsService {
+  /**
+   * Method used to retrieve current scraper configuration from backend
+   * @returns promise containing the operation response text or error
+   */
   static async getConfig() {
     const url = `/api/v1/config`;
     const requestOpts = CommonService.createRequestOptions("GET");
@@ -13,6 +17,11 @@ export class SettingsService {
     throw new Error(`Cannot get current configuration: ${errorDetails}`);
   }
 
+  /**
+   * Method used to invoke the import configuration action from backend
+   * @param {File} configFile The configuration file which contents should be imported
+   * @returns promise containing the operation response text or error
+   */
   static async importConfig(configFile) {
     const url = `/api/v1/settings/import`;
     const requestBody = await configFile.files[0].text();

--- a/public/js/service-settings.js
+++ b/public/js/service-settings.js
@@ -1,0 +1,15 @@
+import { CommonService } from "./service-common.js";
+
+export class SettingsService {
+  static async importConfig(configFile) {
+    const url = `/api/v1/settings/import`;
+    const requestOpts = CommonService.createRequestOptions("POST", configFile, CommonService.TYPE_JSON);
+    const response = await fetch(url, requestOpts);
+    if (response.status === 200) {
+      return response.json();
+    }
+    const errorResponse = await response.json();
+    const errorDetails = CommonService.getErrorDetails(errorResponse);
+    throw new Error(`Cannot import configuration: ${errorDetails}`);
+  }
+}

--- a/public/js/service-settings.js
+++ b/public/js/service-settings.js
@@ -3,7 +3,8 @@ import { CommonService } from "./service-common.js";
 export class SettingsService {
   static async importConfig(configFile) {
     const url = `/api/v1/settings/import`;
-    const requestOpts = CommonService.createRequestOptions("POST", configFile, CommonService.TYPE_JSON);
+    const requestBody = await configFile.files[0].text();
+    const requestOpts = CommonService.createRequestOptions("POST", requestBody, CommonService.TYPE_JSON);
     const response = await fetch(url, requestOpts);
     if (response.status === 200) {
       return response.json();

--- a/public/js/service-settings.js
+++ b/public/js/service-settings.js
@@ -1,6 +1,18 @@
 import { CommonService } from "./service-common.js";
 
 export class SettingsService {
+  static async getConfig() {
+    const url = `/api/v1/config`;
+    const requestOpts = CommonService.createRequestOptions("GET");
+    const response = await fetch(url, requestOpts);
+    if (response.status === 200) {
+      return response.json();
+    }
+    const errorResponse = await response.json();
+    const errorDetails = CommonService.getErrorDetails(errorResponse);
+    throw new Error(`Cannot get current configuration: ${errorDetails}`);
+  }
+
   static async importConfig(configFile) {
     const url = `/api/v1/settings/import`;
     const requestBody = await configFile.files[0].text();

--- a/public/layouts/main.handlebars
+++ b/public/layouts/main.handlebars
@@ -68,6 +68,9 @@
             <a href="/status" title="show detailed status" target="_self">
               <i class="fa fa-dashboard" id="show-dashboard"></i>
             </a>
+            <a href="/settings" title="show settings" target="_self">
+              <i class="fa fa-wrench" id="show-settings"></i>
+            </a>
             {{/if}}
           </div>
           <a href="https://github.com/piopon" title="show author" target="_blank">

--- a/public/layouts/main.handlebars
+++ b/public/layouts/main.handlebars
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="/css/components.css" />
     <link rel="stylesheet" href="/css/status.css" />
     <link rel="stylesheet" href="/css/user.css" />
+    <link rel="stylesheet" href="/css/settings.css" />
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="icon" type="image/x-icon" href="/img/icon/favicon-32.ico" />
     <link href="https://fonts.googleapis.com/css2?family=Sedgwick+Ave&display=swap" rel="stylesheet" />

--- a/public/layouts/main.handlebars
+++ b/public/layouts/main.handlebars
@@ -31,7 +31,7 @@
       {{!-- page content --}}
       <div id="main-content">
         <header id="content-header">
-          {{#if (eq type "status")}}
+          {{#if (or (eq type "status") (eq type "settings"))}}
           <h3><a href="." title="homepage"><i class="fa fa-chevron-left"></i></a> {{title}}</h3>
           {{else}}
           <h3>{{title}}</h3>
@@ -56,7 +56,7 @@
       <footer id="main-footer">
         <h3>developed with 💚 pnk @ {{year}}</h3>
         <div id="footer-links">
-          {{#if (eq type "status")}}
+          {{#if (or (eq type "status") (eq type "settings"))}}
           <div id="status-preview" class="expanded">
           {{else}}
           <div id="status-preview" class="collapsed">

--- a/public/partials/component.handlebars
+++ b/public/partials/component.handlebars
@@ -7,7 +7,7 @@
       {{#if (and (eq name "data") (gt (length @root.extras) 0))}}
         {{> widget type="combo" parent=(append "component-" name) label="auxiliary" options=@root.extras value=component.auxiliary }}
       {{else if (eq name "image")}}
-        {{> widget type="file" parent=(append "component-" name) label="auxiliary" value=component.auxiliary }}
+        {{> widget type="image" parent=(append "component-" name) label="auxiliary" value=component.auxiliary }}
       {{else}}
         {{> widget type="text" parent=(append "component-" name) label="auxiliary" value=component.auxiliary }}
       {{/if}}

--- a/public/partials/widget.handlebars
+++ b/public/partials/widget.handlebars
@@ -24,7 +24,7 @@
         {{/each}}
       </form>
     </dialog>
-  {{else if (eq type "file")}}
+  {{else if (eq type "image")}}
     <div class="{{parent}}-file-container">
       <input type="file" name="{{label}}-file" class="{{parent}}-{{label}}-file" accept="image/*"/>
       <input type="button" name="{{label}}-select" class="{{parent}}-{{label}}-button"

--- a/public/partials/widget.handlebars
+++ b/public/partials/widget.handlebars
@@ -36,6 +36,16 @@
       />
       <input type="button" name="{{label}}-upload" class="{{parent}}-{{label}}-submit" value="upload"/>
     </div>
+  {{else if (eq type "file")}}
+    <div class="{{parent}}-file-container">
+      {{#if (gt (length options) 0)}}
+        <input type="file" name="{{label}}-file" class="{{parent}}-{{label}}-file" accept="{{options}}"/>
+        <input type="button" name="{{label}}-select" class="{{parent}}-{{label}}-button" value="{{value}}"/>
+        <input type="button" name="{{label}}-apply" class="{{parent}}-{{label}}-apply" value="apply"/>
+      {{else}}
+        <input type="button" name="{{label}}-apply" class="{{parent}}-{{label}}-apply" value="{{value}}"/>
+      {{/if}}
+    </div>
   {{else}}
     <input type="{{type}}" class="{{parent}}-{{label}}" name="{{label}}" value="{{value}}" {{#if disable}}disabled{{/if}}/>
   {{/if}}

--- a/public/settings.handlebars
+++ b/public/settings.handlebars
@@ -1,6 +1,6 @@
 <section class="settings-dashboard">
   <div class="settings-options">
-    {{> widget type="file" parent="config" label="export" value="Export config" }}
-    {{> widget type="file" parent="config" label="import" options="application/json" value="Import config" }}
+    {{> widget type="file" classes=" half" parent="config" label="export" value="export current config" }}
+    {{> widget type="file" classes=" half" parent="config" label="import" options="application/json" value="select config file" }}
   </div>
 </section>

--- a/public/settings.handlebars
+++ b/public/settings.handlebars
@@ -4,3 +4,4 @@
     {{> widget type="file" classes=" half" parent="config" label="import" options="application/json" value="select config file" }}
   </div>
 </section>
+<div id="toastBox"></div>

--- a/public/settings.handlebars
+++ b/public/settings.handlebars
@@ -1,5 +1,6 @@
 <section class="settings-dashboard">
   <div class="settings-options">
-    {{> widget type="button" parent="config" label="export" value="Export config" }}
+    {{> widget type="file" parent="config" label="export" value="Export config" }}
+    {{> widget type="file" parent="config" label="import" options="application/json" value="Import config" }}
   </div>
 </section>

--- a/public/settings.handlebars
+++ b/public/settings.handlebars
@@ -1,0 +1,5 @@
+<section class="settings-dashboard">
+  <div class="settings-options">
+    {{> widget type="button" parent="config" label="export" value="Export config" }}
+  </div>
+</section>

--- a/src/components/web-server.js
+++ b/src/components/web-server.js
@@ -4,10 +4,11 @@ import { ComponentType } from "../config/app-types.js";
 import { ConfigRouter } from "../routes/api/config-router.js";
 import { DataRouter } from "../routes/api/data-router.js";
 import { ParamsParser } from "../middleware/params-parser.js";
-import { RequestLogger } from "../middleware/request-logger.js";
-import { StatusRouter } from "../routes/api/status-router.js";
 import { StatusLogger } from "./status-logger.js";
+import { RequestLogger } from "../middleware/request-logger.js";
 import { ViewRouter } from "../routes/view/view-router.js";
+import { StatusRouter } from "../routes/api/status-router.js";
+import { SettingsRouter } from "../routes/api/settings-router.js";
 
 import cors from "cors";
 import express from "express";
@@ -101,6 +102,7 @@ export class WebServer {
       ["/api/v1/data", new DataRouter(this.#setupConfig.usersDataConfig)],
       ["/api/v1/config", new ConfigRouter(this.#components)],
       ["/api/v1/status", new StatusRouter(this.#status, this.#components)],
+      ["/api/v1/settings", new SettingsRouter()],
     ]);
     routes.forEach((router, url) => server.use(url, router.createRoutes()));
 

--- a/src/components/web-server.js
+++ b/src/components/web-server.js
@@ -102,7 +102,7 @@ export class WebServer {
       ["/api/v1/data", new DataRouter(this.#setupConfig.usersDataConfig)],
       ["/api/v1/config", new ConfigRouter(this.#components)],
       ["/api/v1/status", new StatusRouter(this.#status, this.#components)],
-      ["/api/v1/settings", new SettingsRouter()],
+      ["/api/v1/settings", new SettingsRouter(this.#components)],
     ]);
     routes.forEach((router, url) => server.use(url, router.createRoutes()));
 

--- a/src/routes/api/settings-router.js
+++ b/src/routes/api/settings-router.js
@@ -1,0 +1,11 @@
+import express from "express";
+
+export class SettingsRouter {
+  createRoutes() {
+    const router = express.Router();
+    router.post("/import", async (request, response) => {
+      response.status(200).json("OK");
+    });
+    return router;
+  }
+}

--- a/src/routes/api/settings-router.js
+++ b/src/routes/api/settings-router.js
@@ -7,10 +7,18 @@ import express from "express";
 export class SettingsRouter {
   #components = undefined;
 
+  /**
+   * Creates a new settings router for managing scraper application settings
+   * @param {Object} components The web components object used in settings router
+   */
   constructor(components) {
     this.#components = components;
   }
 
+  /**
+   * Method used to create routes for settings adjustment values
+   * @returns router object for handling settings requests
+   */
   createRoutes() {
     const router = express.Router();
     router.post("/import", async (request, response) => {
@@ -30,6 +38,11 @@ export class SettingsRouter {
     return router;
   }
 
+  /**
+   * Method used to validate the settings router endpoint query parameters
+   * @param {Object} params The query parameters which should be validated
+   * @returns an object with validation result (true/false) and an optional cause (if validation NOK)
+   */
   #validateQueryParams(params) {
     const queryValidation = new Ajv().compile({
       type: "object",
@@ -38,6 +51,11 @@ export class SettingsRouter {
     return { valid: queryValidation(params), cause: queryValidation.errors };
   }
 
+  /**
+   * Method used to validate request body for correct settings object
+   * @param {Object} requestBody The object which shoulde be validated
+   * @returns the parsed and validated config if ok, error cause otherwise
+   */
   #validateBody(requestBody) {
     // validate JSON structure of the request body content
     const schemaValidate = new Ajv().compile(ScrapConfig.getRequestBodySchema());
@@ -53,6 +71,12 @@ export class SettingsRouter {
     return { content: parsedBody, cause: undefined };
   }
 
+  /**
+   * Method handling the core import configuration action
+   * @param {Object} user The user for which we want to import configuration
+   * @param {Object} config The configuration to be imported for specified user
+   * @returns the import action status and message with in-depth details
+   */
   async #importConfig(user, config) {
     try {
       // get inital config content from user object (every registered user will have one)

--- a/src/routes/api/settings-router.js
+++ b/src/routes/api/settings-router.js
@@ -83,11 +83,11 @@ export class SettingsRouter {
       const configContent = await ScrapConfig.getDatabaseModel().findById(user.config);
       try {
         configContent.groups = [];
-        config.groups.forEach(group => configContent.groups.push(group));
+        config.groups.forEach((group) => configContent.groups.push(group));
         configContent.user = user._id;
         await configContent.save();
         this.#components.runComponents(ComponentType.CONFIG, "update", user, configContent);
-        return { status: 200 , message: `Imported configuration for user ${user.name}` };
+        return { status: 200, message: `Imported configuration for user ${user.name}` };
       } catch (error) {
         return { status: 400, message: error.message };
       }

--- a/src/routes/api/settings-router.js
+++ b/src/routes/api/settings-router.js
@@ -1,3 +1,4 @@
+import { ComponentType } from "../../config/app-types.js";
 import { ScrapConfig } from "../../model/scrap-config.js";
 
 import Ajv from "ajv";

--- a/src/routes/api/settings-router.js
+++ b/src/routes/api/settings-router.js
@@ -4,6 +4,12 @@ import Ajv from "ajv";
 import express from "express";
 
 export class SettingsRouter {
+  #components = undefined;
+
+  constructor(components) {
+    this.#components = components;
+  }
+
   createRoutes() {
     const router = express.Router();
     router.post("/import", async (request, response) => {
@@ -55,6 +61,7 @@ export class SettingsRouter {
         config.groups.forEach(group => configContent.groups.push(group));
         configContent.user = user._id;
         await configContent.save();
+        this.#components.runComponents(ComponentType.CONFIG, "update", user, configContent);
         return { status: 200 , message: `Imported configuration for user ${user.name}` };
       } catch (error) {
         return { status: 400, message: error.message };

--- a/src/routes/api/settings-router.js
+++ b/src/routes/api/settings-router.js
@@ -1,11 +1,47 @@
+import { ScrapConfig } from "../../model/scrap-config.js";
+
+import Ajv from "ajv";
 import express from "express";
 
 export class SettingsRouter {
   createRoutes() {
     const router = express.Router();
     router.post("/import", async (request, response) => {
+      const validationResult = this.#validateQueryParams(request.query);
+      if (!validationResult.valid) {
+        response.status(400).json(validationResult.cause);
+        return;
+      }
+      const bodyValidation = this.#validateBody(request.body);
+      if (!bodyValidation.content) {
+        response.status(400).json(bodyValidation.cause);
+        return;
+      }
       response.status(200).json("OK");
     });
     return router;
+  }
+
+  #validateQueryParams(params) {
+    const queryValidation = new Ajv().compile({
+      type: "object",
+      additionalProperties: false,
+    });
+    return { valid: queryValidation(params), cause: queryValidation.errors };
+  }
+
+  #validateBody(requestBody) {
+    // validate JSON structure of the request body content
+    const schemaValidate = new Ajv().compile(ScrapConfig.getRequestBodySchema());
+    if (!schemaValidate(requestBody)) {
+      return { content: undefined, cause: schemaValidate.errors };
+    }
+    // validate JSON values of the request body content
+    const parsedBody = new ScrapConfig(requestBody);
+    const valueValidate = parsedBody.checkValues().errors;
+    if (valueValidate.length > 0) {
+      return { content: undefined, cause: valueValidate[0] };
+    }
+    return { content: parsedBody, cause: undefined };
   }
 }

--- a/src/routes/api/settings-router.js
+++ b/src/routes/api/settings-router.js
@@ -53,6 +53,8 @@ export class SettingsRouter {
       try {
         // try to copy all values to config object
         configContent.copyValues(config);
+        configContent.user = user._id;
+        await configContent.save();
         return { status: 200 , message: `Imported configuration for user ${user.name}` };
       } catch (error) {
         return { status: 400, message: error.message };

--- a/src/routes/api/settings-router.js
+++ b/src/routes/api/settings-router.js
@@ -51,8 +51,8 @@ export class SettingsRouter {
       // get inital config content from user object (every registered user will have one)
       const configContent = await ScrapConfig.getDatabaseModel().findById(user.config);
       try {
-        // try to copy all values to config object
-        configContent.copyValues(config);
+        configContent.groups = [];
+        config.groups.forEach(group => configContent.groups.push(group));
         configContent.user = user._id;
         await configContent.save();
         return { status: 200 , message: `Imported configuration for user ${user.name}` };

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -60,6 +60,9 @@ export class ViewRouter {
         statusTypes: this.#getSupportedStatusTypes(),
       })
     );
+    router.get("/settings", AccessChecker.canViewContent, (request, response) =>
+      response.render("settings", {})
+    );
   }
 
   /**

--- a/src/routes/view/view-router.js
+++ b/src/routes/view/view-router.js
@@ -61,7 +61,11 @@ export class ViewRouter {
       })
     );
     router.get("/settings", AccessChecker.canViewContent, (request, response) =>
-      response.render("settings", {})
+      response.render("settings", {
+        title: "scraper settings",
+        type: "settings",
+        user: request.user.name,
+      })
     );
   }
 

--- a/test/routes/view/view-router.test.js
+++ b/test/routes/view/view-router.test.js
@@ -26,6 +26,7 @@ describe("createRoutes() method", () => {
     const expectedRoutes = [
       { path: "/", method: "get" },
       { path: "/status", method: "get" },
+      { path: "/settings", method: "get" },
       { path: "/image", method: "post" },
     ];
     const createdRoutes = testRouter.createRoutes();


### PR DESCRIPTION
This patch fixes #159 
Now a separate settings page is available after logging in where user can export its scraper configuration to a JSON file and save it locally. Alongside there's also a feature which allows the user to select a JSON file with scraper configuration content (is validated) and import it in place of currently existing one.