### PR TITLE
Fixed challenge issue with network with proxy

### DIFF
--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -142,7 +142,7 @@ export class AuthConfig {
         const currentChallenge = ChallengeUtils.generate({
           name: user[0].name,
           mail: user[0].email,
-          address: RegexUtils.getIpAddress(request.headers['x-forwarded-for'] || request.connection.remoteAddress),
+          address: RegexUtils.getIpAddress(request.headers["x-forwarded-for"] || request.connection.remoteAddress),
         });
         if (!(await bcrypt.compare(currentChallenge, request.query.challenge))) {
           // provided challenge does not match the reference one - incorrect login data

--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -142,7 +142,7 @@ export class AuthConfig {
         const currentChallenge = ChallengeUtils.generate({
           name: user[0].name,
           mail: user[0].email,
-          address: request.connection.remoteAddress,
+          address: request.headers['x-forwarded-for'] || request.connection.remoteAddress,
         });
         if (!(await bcrypt.compare(currentChallenge, request.query.challenge))) {
           // provided challenge does not match the reference one - incorrect login data

--- a/src/config/auth-config.js
+++ b/src/config/auth-config.js
@@ -142,7 +142,7 @@ export class AuthConfig {
         const currentChallenge = ChallengeUtils.generate({
           name: user[0].name,
           mail: user[0].email,
-          address: request.headers['x-forwarded-for'] || request.connection.remoteAddress,
+          address: RegexUtils.getIpAddress(request.headers['x-forwarded-for'] || request.connection.remoteAddress),
         });
         if (!(await bcrypt.compare(currentChallenge, request.query.challenge))) {
           // provided challenge does not match the reference one - incorrect login data

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -108,7 +108,11 @@ export class AuthRouter {
         if (!dbUser) {
           return response.status(400).json({ error: "Token retrieval error" });
         }
-        const challengeData = { name: user.name, mail: user.email, address: request.connection.remoteAddress };
+        const challengeData = {
+          name: user.name,
+          mail: user.email,
+          address: request.headers["x-forwarded-for"] || request.connection.remoteAddress,
+        };
         const challenge = bcrypt.hashSync(ChallengeUtils.generate(challengeData), this.#config.hashSalt);
         dbUser.challenge = challenge + ChallengeUtils.serializeDeadline();
         await dbUser.save();

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -2,11 +2,12 @@ import { AccessChecker } from "../../middleware/access-checker.js";
 import { ComponentType } from "../../config/app-types.js";
 import { ScrapConfig } from "../../model/scrap-config.js";
 import { ScrapUser } from "../../model/scrap-user.js";
+import { ChallengeUtils } from "../../utils/challenge-utils.js";
+import { RegexUtils } from "../../utils/regex-utils.js";
 
 import jwt from "jsonwebtoken";
 import express from "express";
 import bcrypt from "bcrypt";
-import { ChallengeUtils } from "../../utils/challenge-utils.js";
 
 export class AuthRouter {
   #components = undefined;

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -111,7 +111,7 @@ export class AuthRouter {
         const challengeData = {
           name: user.name,
           mail: user.email,
-          address: request.headers["x-forwarded-for"] || request.connection.remoteAddress,
+          address: RegexUtils.getIpAddress(request.headers["x-forwarded-for"] || request.connection.remoteAddress),
         };
         const challenge = bcrypt.hashSync(ChallengeUtils.generate(challengeData), this.#config.hashSalt);
         dbUser.challenge = challenge + ChallengeUtils.serializeDeadline();

--- a/src/utils/regex-utils.js
+++ b/src/utils/regex-utils.js
@@ -18,7 +18,8 @@ export class RegexUtils {
   }
 
   static getIpAddress(input) {
-    return input.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/g);
+    const match = input.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/g);
+    return match ? match[0] : null;
   }
 
   /**

--- a/src/utils/regex-utils.js
+++ b/src/utils/regex-utils.js
@@ -17,6 +17,10 @@ export class RegexUtils {
     return string.replace(",", ".").match(/\d+(?:\.\d+)?/g);
   }
 
+  static getIpAddress(input) {
+    return input.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/g);
+  }
+
   /**
    * Method used to check if the provided string value is an unsigned integer
    * @param {String} string The input string value to be checked

--- a/test/config/auth-config.test.js
+++ b/test/config/auth-config.test.js
@@ -308,7 +308,9 @@ describe("auth object with remote-login strategy", () => {
       jest.spyOn(ScrapUser, "getDatabaseModel").mockImplementationOnce(mock);
       jest.spyOn(bcrypt, "compare").mockResolvedValue(true);
       await testVerify(mockRequest, doneMock);
-      expect(doneMock).toHaveBeenCalledWith(null, false, { message: "Outdated challenge data. Please refresh it and try again." });
+      expect(doneMock).toHaveBeenCalledWith(null, false, {
+        message: "Outdated challenge data. Please refresh it and try again.",
+      });
     });
     describe("database error occurs", () => {
       const mockRequest = {

--- a/test/config/auth-config.test.js
+++ b/test/config/auth-config.test.js
@@ -249,6 +249,7 @@ describe("auth object with remote-login strategy", () => {
     const testVerify = authObj._strategies["remote-login"]._verify;
     doneMock = jest.fn();
     const mockRequest = {
+      headers: [],
       query: { challenge: challengeString },
       connection: { remoteAddress: "127.0.0.1" },
     };
@@ -268,6 +269,7 @@ describe("auth object with remote-login strategy", () => {
     test("multiple users were found", async () => {
       doneMock = jest.fn();
       const mockRequest = {
+        headers: [],
         query: { challenge: "does,not,matter,in,this,test" },
         connection: { remoteAddress: "127.0.0.1" },
       };
@@ -281,6 +283,7 @@ describe("auth object with remote-login strategy", () => {
     test("challenge base does not match", async () => {
       doneMock = jest.fn();
       const mockRequest = {
+        headers: [],
         query: { challenge: "does,not,matter" },
         connection: { remoteAddress: "127.0.0.1" },
       };
@@ -295,6 +298,7 @@ describe("auth object with remote-login strategy", () => {
       const challengeString = ">mena,tes@tmena,10.0.7.12%1";
       doneMock = jest.fn();
       const mockRequest = {
+        headers: [],
         query: { challenge: challengeString },
         connection: { remoteAddress: "127.0.0.1" },
       };
@@ -308,6 +312,7 @@ describe("auth object with remote-login strategy", () => {
     });
     describe("database error occurs", () => {
       const mockRequest = {
+        headers: [],
         query: { challenge: "does,not,matter" },
         connection: { remoteAddress: "127.0.0.1" },
       };

--- a/test/utils/regex-utils.test.js
+++ b/test/utils/regex-utils.test.js
@@ -53,6 +53,11 @@ describe("getPrices", () => {
 });
 
 describe("getIpAddress", () => {
+  test("returns correct IP when only IP is present", () => {
+    const input = "1.2.3.4";
+    const result = "1.2.3.4";
+    expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
+  });
   test("returns correct IP when extra suffix is present", () => {
     const input = "192.16.23.112<-IP ;)";
     const result = "192.16.23.112";

--- a/test/utils/regex-utils.test.js
+++ b/test/utils/regex-utils.test.js
@@ -52,6 +52,35 @@ describe("getPrices", () => {
   });
 });
 
+describe("getIpAddress", () => {
+  test("returns correct IP with extra suffix", () => {
+    const input = "192.16.23.112<-IP ;)";
+    const result = ["192.16.23.112"];
+    expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
+  });
+  test("returns correct IP with extra prefix", () => {
+    const input = "::ffff:192.168.0.29";
+    const result = ["192.168.0.29"];
+    expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
+  });
+  test("returns correct price with extra suffix and prefix", () => {
+    const input = "::ffff:10.91.112.115<-IP 2;)";
+    const result = ["10.91.112.115"];
+    expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
+  });
+  test("returns correct price with multiple values", () => {
+    const input = "IPs: 192.16.23.112<-IP | ::ffff:10.91.112.115";
+    const result = ["192.16.23.112", "10.91.112.115"];
+    expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
+  });
+  test("throws if input object is null", () => {
+    expect(() => RegexUtils.getIpAddress(null)).toThrow(TypeError);
+  });
+  test("throws if input object is undefined", () => {
+    expect(() => RegexUtils.getIpAddress(undefined)).toThrow(TypeError);
+  });
+});
+
 describe("isUnsignedInteger", () => {
   test("returns true when unsigned integer is used", () => {
     expect(RegexUtils.isUnsignedInteger("1234")).toBe(true);

--- a/test/utils/regex-utils.test.js
+++ b/test/utils/regex-utils.test.js
@@ -55,22 +55,22 @@ describe("getPrices", () => {
 describe("getIpAddress", () => {
   test("returns correct IP with extra suffix", () => {
     const input = "192.16.23.112<-IP ;)";
-    const result = ["192.16.23.112"];
+    const result = "192.16.23.112";
     expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
   });
   test("returns correct IP with extra prefix", () => {
     const input = "::ffff:192.168.0.29";
-    const result = ["192.168.0.29"];
+    const result = "192.168.0.29";
     expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
   });
   test("returns correct price with extra suffix and prefix", () => {
     const input = "::ffff:10.91.112.115<-IP 2;)";
-    const result = ["10.91.112.115"];
+    const result = "10.91.112.115";
     expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
   });
-  test("returns correct price with multiple values", () => {
+  test("returns first IP when multiple values found", () => {
     const input = "IPs: 192.16.23.112<-IP | ::ffff:10.91.112.115";
-    const result = ["192.16.23.112", "10.91.112.115"];
+    const result = "192.16.23.112";
     expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
   });
   test("throws if input object is null", () => {

--- a/test/utils/regex-utils.test.js
+++ b/test/utils/regex-utils.test.js
@@ -53,17 +53,17 @@ describe("getPrices", () => {
 });
 
 describe("getIpAddress", () => {
-  test("returns correct IP with extra suffix", () => {
+  test("returns correct IP when extra suffix is present", () => {
     const input = "192.16.23.112<-IP ;)";
     const result = "192.16.23.112";
     expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
   });
-  test("returns correct IP with extra prefix", () => {
+  test("returns correct IP when extra prefix is present", () => {
     const input = "::ffff:192.168.0.29";
     const result = "192.168.0.29";
     expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);
   });
-  test("returns correct price with extra suffix and prefix", () => {
+  test("returns correct IP when extra suffix and prefix are present", () => {
     const input = "::ffff:10.91.112.115<-IP 2;)";
     const result = "10.91.112.115";
     expect(RegexUtils.getIpAddress(input)).toStrictEqual(result);


### PR DESCRIPTION
This patch fixes #180 
Now we're checking forwarded header value before socket's client IP to correctly compare challenge data.