### PR TITLE
Correctly cleaning demo session

### DIFF
--- a/src/components/web-scraper.js
+++ b/src/components/web-scraper.js
@@ -160,31 +160,33 @@ export class WebScraper {
    * Method used to clean retrieved data for specified user
    * @param {String} userEmail The email of the user which data we want to clean
    */
-  clean(userEmail) {
+  async clean(userEmail) {
     const userDataDir = path.join(this.#userConfig.path, userEmail);
-    if (fs.existsSync(userDataDir)) {
+    if (!fs.existsSync(userDataDir)) {
+      return true;
+    }
+    const maxAttempts = 3;
+    const cleanTimeout = this.#scrapConfig.cleanErrorWait;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        fs.rmSync(userDataDir, { recursive: true, force: true });
-        // for some undefined reasons profile files are saved outside user directory
-        const usersContents = fs.readdirSync(this.#userConfig.path);
-        for (const item of usersContents) {
-          const fullPath = path.join(this.#userConfig.path, item);
-          const statObj = fs.statSync(fullPath);
-          if (statObj.isFile()) {
-            fs.unlinkSync(fullPath);
-          }
-        }
+        fs.rmSync(userDataDir, {
+          recursive: true,
+          force: true,
+          maxRetries: 10,
+          retryDelay: 200,
+        });
         this.#status.info(`${userEmail}: removed data.`);
+        return true;
       } catch (error) {
-        const session = this.#sessions.get(userEmail);
-        if (!session.cleaning) {
-          const cleanTimeout = this.#scrapConfig.cleanErrorWait;
-          session.cleaning = setInterval(() => this.clean(userEmail), cleanTimeout);
-          this.#status.warning(`${userEmail}: cannot remove data. Retrying in ${cleanTimeout / 1_000} second(s)...`);
-        } else {
-          session.cleaning = undefined;
-          this.#status.warning(`${userEmail}: failed to remove data...`);
+        if (attempt < maxAttempts) {
+          this.#status.warning(
+            `${userEmail}: cannot remove data. Retrying in ${cleanTimeout / 1_000} second(s)... [${attempt}/${maxAttempts}]`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, cleanTimeout));
+          continue;
         }
+        this.#status.warning(`${userEmail}: failed to remove data... (${error.message})`);
+        return false;
       }
     }
   }

--- a/src/components/web-scraper.js
+++ b/src/components/web-scraper.js
@@ -169,7 +169,7 @@ export class WebScraper {
     const cleanTimeout = this.#scrapConfig.cleanErrorWait;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        fs.rmSync(userDataDir, {
+        await fs.promises.rm(userDataDir, {
           recursive: true,
           force: true,
           maxRetries: 10,

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -141,16 +141,20 @@ export class AuthRouter {
         if (!request.remoteLogout) {
           response.redirect("/auth/login");
         }
-        if (userWithChallenge) {
-          userWithChallenge.challenge = undefined;
-          await userWithChallenge.save();
-        }
-        if (temporaryUser) {
-          await ScrapUser.getDatabaseModel().deleteOne({ email: temporaryUser.email });
-          await ScrapConfig.getDatabaseModel().deleteOne({ user: temporaryUser._id });
-          // we should stop logout action components and clean their temporary data
-          this.#components.runComponents(ComponentType.LOGOUT, "stop", temporaryUser.email, "Demo session ended.");
-          this.#components.runComponents(ComponentType.LOGOUT, "clean", temporaryUser.email);
+        try {
+          if (userWithChallenge) {
+            userWithChallenge.challenge = undefined;
+            await userWithChallenge.save();
+          }
+          if (temporaryUser) {
+            await ScrapUser.getDatabaseModel().deleteOne({ email: temporaryUser.email });
+            await ScrapConfig.getDatabaseModel().deleteOne({ user: temporaryUser._id });
+            // stop browser first and clean files only after the process is closed
+            await this.#components.runComponents(ComponentType.LOGOUT, "stop", temporaryUser.email, "Demo session ended.");
+            await this.#components.runComponents(ComponentType.LOGOUT, "clean", temporaryUser.email);
+          }
+        } catch (error) {
+          return next(error);
         }
       });
     };

--- a/src/routes/view/auth-router.js
+++ b/src/routes/view/auth-router.js
@@ -138,9 +138,6 @@ export class AuthRouter {
       const temporaryUser = request.user?.hostUser ? request.user : undefined;
       request.logout(async (err) => {
         if (err) return next(err);
-        if (!request.remoteLogout) {
-          response.redirect("/auth/login");
-        }
         try {
           if (userWithChallenge) {
             userWithChallenge.challenge = undefined;
@@ -153,8 +150,13 @@ export class AuthRouter {
             await this.#components.runComponents(ComponentType.LOGOUT, "stop", temporaryUser.email, "Demo session ended.");
             await this.#components.runComponents(ComponentType.LOGOUT, "clean", temporaryUser.email);
           }
+          if (!request.remoteLogout) {
+            return response.redirect("/auth/login");
+          }
         } catch (error) {
-          return next(error);
+          if (!response.headersSent) {
+            return next(error);
+          }
         }
       });
     };

--- a/test/components/web-scraper.test.js
+++ b/test/components/web-scraper.test.js
@@ -269,6 +269,45 @@ describe("update() method", () => {
   });
 });
 
+describe("clean() method", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("returns true when user directory does not exist", async () => {
+    const testScraper = new WebScraper({
+      minLogLevel: LogLevel.INFO,
+      scraperConfig: { cleanErrorWait: 0, browser: { useEmbedded: true, profileDir: "_profile" } },
+      usersDataConfig: { path: testOwnerRoot, file: path.basename(testOwnerPath) },
+    });
+    const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(false);
+
+    const result = await testScraper.clean("missing@test.com");
+
+    expect(result).toBe(true);
+    expect(existsSpy).toHaveBeenCalled();
+  });
+
+  test("retries on transient delete error and finally returns true", async () => {
+    const testScraper = new WebScraper({
+      minLogLevel: LogLevel.INFO,
+      scraperConfig: { cleanErrorWait: 0, browser: { useEmbedded: true, profileDir: "_profile" } },
+      usersDataConfig: { path: testOwnerRoot, file: path.basename(testOwnerPath) },
+    });
+    const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    const rmSpy = jest
+      .spyOn(fs.promises, "rm")
+      .mockRejectedValueOnce(new Error("EBUSY: resource busy"))
+      .mockResolvedValueOnce();
+
+    const result = await testScraper.clean("retry@test.com");
+
+    expect(result).toBe(true);
+    expect(existsSpy).toHaveBeenCalled();
+    expect(rmSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
 function createDataFile(filePath) {
   try {
     // create parent directory (if needed)


### PR DESCRIPTION
This patch fixes #194 
Now demo users are correctly cleaned when using demo in scraper service and in upper level monitor service.