### PR TITLE
Added GitHub Release archive file to release flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Create release bundle
         run: |
           ARCHIVE_NAME="web-scraper-${{ github.event.release.tag_name }}.tar.gz"
-          git archive --format=tar.gz --output "$ARCHIVE_NAME" HEAD
+          ARCHIVE_PREFIX="web-scraper-${{ github.event.release.tag_name }}/"
+          git archive --format=tar.gz --prefix "$ARCHIVE_PREFIX" --output "$ARCHIVE_NAME" HEAD
           echo "ARCHIVE_NAME=$ARCHIVE_NAME" >> "$GITHUB_ENV"
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,22 @@ jobs:
       - name: Prepare safe release tag
         run: |
           RAW_TAG="${{ github.event.release.tag_name }}"
-          SAFE_TAG="$(echo "$RAW_TAG" | sed -E 's#[^A-Za-z0-9._-]#-#g')"
-          echo "IMAGE_TAG=$SAFE_TAG" >> "$GITHUB_ENV"
+          SAFE_BASE="$(echo "$RAW_TAG" | sed -E 's#[^A-Za-z0-9._-]#-#g')"
+          SAFE_BASE="$(echo "$SAFE_BASE" | sed -E 's#^[.-]+##')"
+          if [ -z "$SAFE_BASE" ]; then
+            SAFE_BASE="r"
+          fi
+          if ! [[ "$SAFE_BASE" =~ ^[A-Za-z0-9_] ]]; then
+            SAFE_BASE="r-$SAFE_BASE"
+          fi
+
+          TAG_HASH="$(printf '%s' "$RAW_TAG" | sha256sum | cut -c1-8)"
+          MAX_BASE_LEN=119
+          SAFE_BASE="${SAFE_BASE:0:$MAX_BASE_LEN}"
+          NORMALIZED_TAG="${SAFE_BASE}-${TAG_HASH}"
+
+          echo "IMAGE_TAG=$NORMALIZED_TAG" >> "$GITHUB_ENV"
+          echo "BUNDLE_TAG=$NORMALIZED_TAG" >> "$GITHUB_ENV"
       - name: Resolve image tags
         id: meta
         uses: docker/metadata-action@v5
@@ -48,12 +62,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
       - name: Create release bundle
         run: |
-          RAW_TAG="${{ github.event.release.tag_name }}"
-          SAFE_TAG="$(echo "$RAW_TAG" | sed -E 's#[^A-Za-z0-9._-]#-#g')"
-          ARCHIVE_NAME="web-scraper-${SAFE_TAG}.tar.gz"
-          ARCHIVE_PREFIX="web-scraper-${SAFE_TAG}/"
+          ARCHIVE_NAME="web-scraper-${{ env.BUNDLE_TAG }}.tar.gz"
+          ARCHIVE_PREFIX="web-scraper-${{ env.BUNDLE_TAG }}/"
           git archive --format=tar.gz --prefix "$ARCHIVE_PREFIX" --output "$ARCHIVE_NAME" HEAD
-          echo "BUNDLE_TAG=$SAFE_TAG" >> "$GITHUB_ENV"
           echo "ARCHIVE_NAME=$ARCHIVE_NAME" >> "$GITHUB_ENV"
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,14 +43,17 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
       - name: Create release bundle
         run: |
-          ARCHIVE_NAME="web-scraper-${{ github.event.release.tag_name }}.tar.gz"
-          ARCHIVE_PREFIX="web-scraper-${{ github.event.release.tag_name }}/"
+          RAW_TAG="${{ github.event.release.tag_name }}"
+          SAFE_TAG="$(echo "$RAW_TAG" | sed -E 's#[^A-Za-z0-9._-]#-#g')"
+          ARCHIVE_NAME="web-scraper-${SAFE_TAG}.tar.gz"
+          ARCHIVE_PREFIX="web-scraper-${SAFE_TAG}/"
           git archive --format=tar.gz --prefix "$ARCHIVE_PREFIX" --output "$ARCHIVE_NAME" HEAD
+          echo "BUNDLE_TAG=$SAFE_TAG" >> "$GITHUB_ENV"
           echo "ARCHIVE_NAME=$ARCHIVE_NAME" >> "$GITHUB_ENV"
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: web-scraper-${{ github.event.release.tag_name }}
+          name: web-scraper-${{ env.BUNDLE_TAG }}
           path: ${{ env.ARCHIVE_NAME }}
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
@@ -54,6 +58,8 @@ jobs:
           tags: |
             type=raw,value=${{ env.IMAGE_TAG }}
             type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
+      - name: Sync VERSION for release artifacts
+        run: npm run version:sync
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -64,7 +70,7 @@ jobs:
         run: |
           ARCHIVE_NAME="web-scraper-${{ env.BUNDLE_TAG }}.tar.gz"
           ARCHIVE_PREFIX="web-scraper-${{ env.BUNDLE_TAG }}/"
-          git archive --format=tar.gz --prefix "$ARCHIVE_PREFIX" --output "$ARCHIVE_NAME" HEAD
+          git ls-files -z | tar --null -T - --transform "s#^#${ARCHIVE_PREFIX}#" -czf "$ARCHIVE_NAME"
           echo "ARCHIVE_NAME=$ARCHIVE_NAME" >> "$GITHUB_ENV"
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,13 +27,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare safe release tag
+        run: |
+          RAW_TAG="${{ github.event.release.tag_name }}"
+          SAFE_TAG="$(echo "$RAW_TAG" | sed -E 's#[^A-Za-z0-9._-]#-#g')"
+          echo "IMAGE_TAG=$SAFE_TAG" >> "$GITHUB_ENV"
       - name: Resolve image tags
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ github.event.release.tag_name }}
+            type=raw,value=${{ env.IMAGE_TAG }}
             type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           name: web-scraper-${{ github.event.release.tag_name }}
           path: ${{ env.ARCHIVE_NAME }}
+          retention-days: 14
           if-no-files-found: error
       - name: Attach archive to GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 # This workflow will publish web-scraper release artifacts
 # Primary artifact: GHCR container image
+# Secondary artifact: GitHub Release archive (.tar.gz)
 
 name: CD web-scraper
 
@@ -14,7 +15,7 @@ jobs:
     env:
       IMAGE_NAME: ghcr.io/${{ github.repository }}
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - uses: actions/checkout@v4
@@ -40,3 +41,18 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+      - name: Create release bundle
+        run: |
+          ARCHIVE_NAME="web-scraper-${{ github.event.release.tag_name }}.tar.gz"
+          git archive --format=tar.gz --output "$ARCHIVE_NAME" HEAD
+          echo "ARCHIVE_NAME=$ARCHIVE_NAME" >> "$GITHUB_ENV"
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-scraper-${{ github.event.release.tag_name }}
+          path: ${{ env.ARCHIVE_NAME }}
+          if-no-files-found: error
+      - name: Attach archive to GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.ARCHIVE_NAME }}


### PR DESCRIPTION
This patch is a part of #193 
After adding the GHCR publish package in task #197 the next part is to add a secondary artifact: GitHub Release archive (.tar.gz) to the flow. This is exactly what this PR is doing.