### PR TITLE
Use status endpoint in Docker healthcheck command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN npm install
 COPY --chown=node:node . .
 EXPOSE $SERVER_PORT
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD node ./scripts/healthcheck-status.js "http://127.0.0.1:${SERVER_PORT}/api/v1/status" || exit 1
+  CMD node ./scripts/healthcheck-status.js "http://127.0.0.1:${SERVER_PORT:-5000}/api/v1/status" || exit 1
 CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:22-slim
 ARG SERVER_PORT=5000
+ENV SERVER_PORT=${SERVER_PORT}
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 RUN apt-get update && apt-get install gnupg wget -y && \
   wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN npm install
 COPY --chown=node:node . .
 EXPOSE $SERVER_PORT
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD wget -qO- "http://127.0.0.1:${SERVER_PORT}/api/v1/status" | node -e "let b='';process.stdin.on('data',c=>b+=c);process.stdin.on('end',()=>{try{const arr=JSON.parse(b);const ok=Array.isArray(arr)&&arr.length>0&&arr.every(x=>x.status==='running');process.exit(ok?0:1);}catch{process.exit(1);}})" || exit 1
+  CMD node ./scripts/healthcheck-status.js "http://127.0.0.1:${SERVER_PORT}/api/v1/status" || exit 1
 CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ USER node
 RUN npm install
 COPY --chown=node:node . .
 EXPOSE $SERVER_PORT
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget -qO- "http://127.0.0.1:${SERVER_PORT}/api/v1/status" | node -e "let b='';process.stdin.on('data',c=>b+=c);process.stdin.on('end',()=>{try{const arr=JSON.parse(b);const ok=Array.isArray(arr)&&arr.length>0&&arr.every(x=>x.status==='running');process.exit(ok?0:1);}catch{process.exit(1);}})" || exit 1
 CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN npm install
 COPY --chown=node:node . .
 EXPOSE $SERVER_PORT
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD node ./scripts/healthcheck-status.js "http://127.0.0.1:${SERVER_PORT:-5000}/api/v1/status" || exit 1
+  CMD node ./scripts/healthcheck-status.js "http://127.0.0.1:${SERVER_PORT:-5000}/api/v1/status"
 CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ CI_USER=[STRING]                 # CI user email
 CI_PASS=[STRING]                 # CI user password
 ```
 
+Docker image healthcheck notes:
+- No extra configuration is required by default.
+- The container healthcheck calls `/api/v1/status` and validates component states.
+  - Default accepted states: `web-database=running`.
+  - Default accepted states: `web-components=running`.
+  - Default accepted states: `web-server=running`.
+  - Default accepted states: `web-scraper=running|stopped`.
+
+> Component names received from status endpoint are trimmed before matching (to support padded logger names).
+
+Optional advanced override is available by setting the `HEALTHCHECK_COMPONENT_STATES` environment variable as a JSON object where key is component name and value is list of accepted states:
+```
+HEALTHCHECK_COMPONENT_STATES={"web-database":["running"],"web-scraper":["running"],"web-components":["running"],"web-server":["running"]}
+```
+
 Additionally, keep a top-level `VERSION` file in repository root.
 This file should contain the full runtime version string in format `version+sha`.
 Default value in repository is used as fallback when git metadata is unavailable.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Docker image healthcheck notes:
 
 Optional advanced override is available by setting the `HEALTHCHECK_COMPONENT_STATES` environment variable as a JSON object where key is component name and value is list of accepted states:
 ```
-HEALTHCHECK_COMPONENT_STATES={"web-database":["running"],"web-scraper":["running"],"web-components":["running"],"web-server":["running"]}
+HEALTHCHECK_COMPONENT_STATES='{"web-database":["running"],"web-scraper":["running"],"web-components":["running"],"web-server":["running"]}'
 ```
 
 Additionally, keep a top-level `VERSION` file in repository root.

--- a/scripts/healthcheck-status.js
+++ b/scripts/healthcheck-status.js
@@ -1,14 +1,50 @@
 const DEFAULT_URL = "http://127.0.0.1:5000/api/v1/status";
-const DEFAULT_COMPONENTS = ["web-database", "web-scraper", "web-components", "web-server"];
+const DEFAULT_COMPONENT_STATES = {
+  "web-database": ["running"],
+  "web-scraper": ["running", "stopped"],
+  "web-components": ["running"],
+  "web-server": ["running"],
+};
 
-function getExpectedComponents() {
-  if (!process.env.HEALTHCHECK_COMPONENTS) {
-    return DEFAULT_COMPONENTS;
+function normalizeStateMap(stateMap) {
+  const normalizedMap = {};
+  for (const [componentName, acceptedStates] of Object.entries(stateMap)) {
+    const normalizedName = String(componentName).trim();
+    if (normalizedName.length === 0) {
+      continue;
+    }
+    const normalizedStates = Array.isArray(acceptedStates)
+      ? acceptedStates.map((state) => String(state).trim().toLowerCase()).filter((state) => state.length > 0)
+      : [];
+    if (normalizedStates.length === 0) {
+      continue;
+    }
+    normalizedMap[normalizedName] = normalizedStates;
+  }
+  return normalizedMap;
+}
+
+function getExpectedComponentStates() {
+  if (!process.env.HEALTHCHECK_COMPONENT_STATES) {
+    return normalizeStateMap(DEFAULT_COMPONENT_STATES);
   }
 
-  return process.env.HEALTHCHECK_COMPONENTS.split(",")
-    .map((name) => name.trim())
-    .filter((name) => name.length > 0);
+  let parsedMap;
+  try {
+    parsedMap = JSON.parse(process.env.HEALTHCHECK_COMPONENT_STATES);
+  } catch (error) {
+    throw new Error(`Invalid HEALTHCHECK_COMPONENT_STATES JSON: ${error.message}`);
+  }
+
+  if (parsedMap == null || typeof parsedMap !== "object" || Array.isArray(parsedMap)) {
+    throw new Error("HEALTHCHECK_COMPONENT_STATES must be a JSON object");
+  }
+
+  const normalizedMap = normalizeStateMap(parsedMap);
+  if (Object.keys(normalizedMap).length === 0) {
+    throw new Error("HEALTHCHECK_COMPONENT_STATES must define at least one component with accepted states");
+  }
+  return normalizedMap;
 }
 
 async function main() {
@@ -40,9 +76,10 @@ async function main() {
     process.exit(1);
   }
 
-  const expectedComponents = getExpectedComponents();
+  const expectedComponentStates = getExpectedComponentStates();
+  const expectedComponents = Object.keys(expectedComponentStates);
   const componentStatus = new Map(
-    payload.map((entry) => [String(entry?.name ?? "").trim(), String(entry?.status ?? "").trim()]),
+    payload.map((entry) => [String(entry?.name ?? "").trim(), String(entry?.status ?? "").trim().toLowerCase()]),
   );
 
   const missingComponents = expectedComponents.filter((name) => !componentStatus.has(name));
@@ -51,9 +88,17 @@ async function main() {
     process.exit(1);
   }
 
-  const notRunningComponents = expectedComponents.filter((name) => componentStatus.get(name) !== "running");
-  if (notRunningComponents.length > 0) {
-    process.stderr.write(`Healthcheck components not running: ${notRunningComponents.join(", ")}\n`);
+  const invalidStateComponents = expectedComponents.filter((name) => {
+    const acceptedStates = expectedComponentStates[name];
+    return !acceptedStates.includes(componentStatus.get(name));
+  });
+  if (invalidStateComponents.length > 0) {
+    const details = invalidStateComponents.map((name) => {
+      const actualState = componentStatus.get(name);
+      const acceptedStates = expectedComponentStates[name].join("|");
+      return `${name}=${actualState} (accepted: ${acceptedStates})`;
+    });
+    process.stderr.write(`Healthcheck components in invalid state: ${details.join(", ")}\n`);
     process.exit(1);
   }
 }

--- a/scripts/healthcheck-status.js
+++ b/scripts/healthcheck-status.js
@@ -1,4 +1,15 @@
 const DEFAULT_URL = "http://127.0.0.1:5000/api/v1/status";
+const DEFAULT_COMPONENTS = ["web-database", "web-scraper", "web-components", "web-server"];
+
+function getExpectedComponents() {
+  if (!process.env.HEALTHCHECK_COMPONENTS) {
+    return DEFAULT_COMPONENTS;
+  }
+
+  return process.env.HEALTHCHECK_COMPONENTS.split(",")
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+}
 
 async function main() {
   const url = process.argv[2] || DEFAULT_URL;
@@ -24,9 +35,25 @@ async function main() {
     process.exit(1);
   }
 
-  const isHealthy = Array.isArray(payload) && payload.length > 0 && payload.every((entry) => entry?.status === "running");
-  if (!isHealthy) {
-    process.stderr.write("Healthcheck detected non-running component status\n");
+  if (!Array.isArray(payload) || payload.length === 0) {
+    process.stderr.write("Healthcheck response is empty or not an array\n");
+    process.exit(1);
+  }
+
+  const expectedComponents = getExpectedComponents();
+  const componentStatus = new Map(
+    payload.map((entry) => [String(entry?.name ?? "").trim(), String(entry?.status ?? "").trim()]),
+  );
+
+  const missingComponents = expectedComponents.filter((name) => !componentStatus.has(name));
+  if (missingComponents.length > 0) {
+    process.stderr.write(`Healthcheck missing expected components: ${missingComponents.join(", ")}\n`);
+    process.exit(1);
+  }
+
+  const notRunningComponents = expectedComponents.filter((name) => componentStatus.get(name) !== "running");
+  if (notRunningComponents.length > 0) {
+    process.stderr.write(`Healthcheck components not running: ${notRunningComponents.join(", ")}\n`);
     process.exit(1);
   }
 }

--- a/scripts/healthcheck-status.js
+++ b/scripts/healthcheck-status.js
@@ -1,4 +1,5 @@
 const DEFAULT_URL = "http://127.0.0.1:5000/api/v1/status";
+const FORBIDDEN_COMPONENT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 const DEFAULT_COMPONENT_STATES = {
   "web-database": ["running"],
   "web-scraper": ["running", "stopped"],
@@ -7,11 +8,14 @@ const DEFAULT_COMPONENT_STATES = {
 };
 
 function normalizeStateMap(stateMap) {
-  const normalizedMap = {};
+  const normalizedMap = Object.create(null);
   for (const [componentName, acceptedStates] of Object.entries(stateMap)) {
     const normalizedName = String(componentName).trim();
     if (normalizedName.length === 0) {
       continue;
+    }
+    if (FORBIDDEN_COMPONENT_KEYS.has(normalizedName)) {
+      throw new Error(`Invalid component name in HEALTHCHECK_COMPONENT_STATES: ${normalizedName}`);
     }
     const normalizedStates = Array.isArray(acceptedStates)
       ? acceptedStates.map((state) => String(state).trim().toLowerCase()).filter((state) => state.length > 0)

--- a/scripts/healthcheck-status.js
+++ b/scripts/healthcheck-status.js
@@ -1,0 +1,37 @@
+const DEFAULT_URL = "http://127.0.0.1:5000/api/v1/status";
+
+async function main() {
+  const url = process.argv[2] || DEFAULT_URL;
+  let response;
+
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    process.stderr.write(`Healthcheck request failed: ${error.message}\n`);
+    process.exit(1);
+  }
+
+  if (!response.ok) {
+    process.stderr.write(`Healthcheck failed with status ${response.status}\n`);
+    process.exit(1);
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    process.stderr.write(`Healthcheck invalid JSON response: ${error.message}\n`);
+    process.exit(1);
+  }
+
+  const isHealthy = Array.isArray(payload) && payload.length > 0 && payload.every((entry) => entry?.status === "running");
+  if (!isHealthy) {
+    process.stderr.write("Healthcheck detected non-running component status\n");
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`Healthcheck unexpected error: ${error.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
This patch fixes #200 
Now status endpoint is used in Docker HEALTHCHECK command via a intermediate script.