### PR TITLE
Added new smoke tests in CD workflow

### DIFF
--- a/.github/actions/create-release-bundle/action.yml
+++ b/.github/actions/create-release-bundle/action.yml
@@ -23,6 +23,8 @@ runs:
       id: bundle
       shell: bash
       run: |
+        set -euo pipefail
+
         ARCHIVE_NAME="web-scraper-${{ inputs.bundleTag }}.tar.gz"
         ARCHIVE_PREFIX="web-scraper-${{ inputs.bundleTag }}/"
 

--- a/.github/actions/create-release-bundle/action.yml
+++ b/.github/actions/create-release-bundle/action.yml
@@ -1,5 +1,5 @@
 name: Create Release Bundle
-description: Create a versioned release tarball from tracked files and upload it as a workflow artifact.
+description: Create a versioned release tarball from an allowlist, verify entries are tracked files, and upload it as a workflow artifact.
 inputs:
   bundleTag:
     description: Normalized tag value used in bundle file and directory names.
@@ -44,6 +44,12 @@ runs:
         while IFS= read -r entry; do
           if [ ! -e "$entry" ]; then
             echo "Missing allowlisted entry: $entry"
+            MISSING=1
+            continue
+          fi
+
+          if ! git ls-files --error-unmatch -- "$entry" >/dev/null 2>&1; then
+            echo "Allowlisted entry is not tracked by git: $entry"
             MISSING=1
           fi
         done < .release-bundle-files.txt

--- a/.github/actions/create-release-bundle/action.yml
+++ b/.github/actions/create-release-bundle/action.yml
@@ -4,6 +4,10 @@ inputs:
   bundleTag:
     description: Normalized tag value used in bundle file and directory names.
     required: true
+  allowlistFile:
+    description: Path to release bundle allowlist file.
+    required: false
+    default: ".github/release-bundle-files.txt"
   retentionDays:
     description: Retention period for the workflow artifact in days.
     required: false
@@ -21,7 +25,34 @@ runs:
       run: |
         ARCHIVE_NAME="web-scraper-${{ inputs.bundleTag }}.tar.gz"
         ARCHIVE_PREFIX="web-scraper-${{ inputs.bundleTag }}/"
-        git ls-files -z | tar --null -T - --transform "s#^#${ARCHIVE_PREFIX}#" -czf "$ARCHIVE_NAME"
+
+        ALLOWLIST_FILE="${{ inputs.allowlistFile }}"
+        if [ ! -f "$ALLOWLIST_FILE" ]; then
+          echo "Release bundle allowlist file not found: $ALLOWLIST_FILE"
+          exit 1
+        fi
+
+        grep -vE '^[[:space:]]*($|#)' "$ALLOWLIST_FILE" > .release-bundle-files.txt
+        if [ ! -s .release-bundle-files.txt ]; then
+          echo "Release bundle allowlist is empty: $ALLOWLIST_FILE"
+          exit 1
+        fi
+
+        MISSING=0
+        while IFS= read -r entry; do
+          if [ ! -e "$entry" ]; then
+            echo "Missing allowlisted entry: $entry"
+            MISSING=1
+          fi
+        done < .release-bundle-files.txt
+        if [ "$MISSING" -ne 0 ]; then
+          exit 1
+        fi
+
+        tar --create --gzip \
+          --file "$ARCHIVE_NAME" \
+          --transform "s#^#${ARCHIVE_PREFIX}#" \
+          --files-from .release-bundle-files.txt
         echo "archiveName=$ARCHIVE_NAME" >> "$GITHUB_OUTPUT"
 
     - name: Upload workflow artifact

--- a/.github/actions/create-release-bundle/action.yml
+++ b/.github/actions/create-release-bundle/action.yml
@@ -41,6 +41,7 @@ runs:
         fi
 
         MISSING=0
+        : > .release-bundle-tracked-files.zlist
         while IFS= read -r entry; do
           if [ ! -e "$entry" ]; then
             echo "Missing allowlisted entry: $entry"
@@ -48,19 +49,31 @@ runs:
             continue
           fi
 
-          if ! git ls-files --error-unmatch -- "$entry" >/dev/null 2>&1; then
-            echo "Allowlisted entry is not tracked by git: $entry"
+          git ls-files -z -- "$entry" > .release-bundle-entry-files.zlist
+          if [ ! -s .release-bundle-entry-files.zlist ]; then
+            echo "Allowlisted entry has no tracked files: $entry"
             MISSING=1
+            continue
           fi
+
+          cat .release-bundle-entry-files.zlist >> .release-bundle-tracked-files.zlist
         done < .release-bundle-files.txt
         if [ "$MISSING" -ne 0 ]; then
           exit 1
         fi
 
+        if [ ! -s .release-bundle-tracked-files.zlist ]; then
+          echo "Resolved tracked file list is empty."
+          exit 1
+        fi
+
+        sort -zu .release-bundle-tracked-files.zlist -o .release-bundle-tracked-files.zlist
+
         tar --create --gzip \
           --file "$ARCHIVE_NAME" \
           --transform "s#^#${ARCHIVE_PREFIX}#" \
-          --files-from .release-bundle-files.txt
+          --null \
+          --files-from .release-bundle-tracked-files.zlist
         echo "archiveName=$ARCHIVE_NAME" >> "$GITHUB_OUTPUT"
 
     - name: Upload workflow artifact

--- a/.github/actions/create-release-bundle/action.yml
+++ b/.github/actions/create-release-bundle/action.yml
@@ -34,7 +34,7 @@ runs:
           exit 1
         fi
 
-        grep -vE '^[[:space:]]*($|#)' "$ALLOWLIST_FILE" > .release-bundle-files.txt
+        grep -vE '^[[:space:]]*($|#)' "$ALLOWLIST_FILE" > .release-bundle-files.txt || true
         if [ ! -s .release-bundle-files.txt ]; then
           echo "Release bundle allowlist is empty: $ALLOWLIST_FILE"
           exit 1

--- a/.github/actions/runtime-smoke-check/action.yml
+++ b/.github/actions/runtime-smoke-check/action.yml
@@ -1,0 +1,76 @@
+name: Runtime Smoke Check
+description: Start MongoDB and app containers, wait for app healthcheck, and always clean up.
+inputs:
+  imageName:
+    description: Docker image to run for smoke validation.
+    required: true
+  timeoutSeconds:
+    description: Max seconds to wait for healthy status.
+    required: false
+    default: "120"
+runs:
+  using: composite
+  steps:
+    - name: Run runtime smoke validation
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        NETWORK_NAME="smoke-net"
+        MONGO_NAME="smoke-mongo"
+        APP_NAME="smoke-app"
+
+        cleanup() {
+          docker rm -f "$APP_NAME" "$MONGO_NAME" >/dev/null 2>&1 || true
+          docker network rm "$NETWORK_NAME" >/dev/null 2>&1 || true
+        }
+        trap cleanup EXIT
+
+        docker network create "$NETWORK_NAME" >/dev/null
+
+        docker run -d --name "$MONGO_NAME" --network "$NETWORK_NAME" \
+          -e MONGO_INITDB_ROOT_USERNAME=smoke \
+          -e MONGO_INITDB_ROOT_PASSWORD=smoke \
+          mongo >/dev/null
+
+        docker run -d --name "$APP_NAME" --network "$NETWORK_NAME" \
+          -e SERVER_PORT=5000 \
+          -e DB_ADDRESS="$MONGO_NAME" \
+          -e DB_PORT=27017 \
+          -e DB_NAME=web-scraper \
+          -e DB_USER=smoke \
+          -e DB_PASSWORD=smoke \
+          -e DEMO_BASE=base@demo.com \
+          -e DEMO_PASS=demo-pass \
+          -e CI_USER=ci@test.local \
+          -e CI_PASS=ci-pass \
+          -e JWT_SECRET=smoke-jwt \
+          -e SESSION_SHA=smoke-session \
+          -e CHALLENGE_PREFIX=smoke \
+          -e CHALLENGE_JOIN=- \
+          -e CHALLENGE_EOL_MINS=10 \
+          -e CHALLENGE_EOL_SEPARATOR=@ \
+          "${{ inputs.imageName }}" >/dev/null
+
+        ATTEMPTS=$(( ${{ inputs.timeoutSeconds }} / 2 ))
+        if [ "$ATTEMPTS" -lt 1 ]; then
+          ATTEMPTS=1
+        fi
+
+        for attempt in $(seq 1 "$ATTEMPTS"); do
+          status=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$APP_NAME")
+          if [ "$status" = "healthy" ]; then
+            echo "Runtime smoke check passed."
+            exit 0
+          fi
+          if [ "$status" = "unhealthy" ]; then
+            echo "Runtime smoke check failed: container reported unhealthy."
+            docker logs "$APP_NAME"
+            exit 1
+          fi
+          sleep 2
+        done
+
+        echo "Runtime smoke check timed out waiting for healthy status."
+        docker logs "$APP_NAME"
+        exit 1

--- a/.github/actions/runtime-smoke-check/action.yml
+++ b/.github/actions/runtime-smoke-check/action.yml
@@ -37,8 +37,33 @@ runs:
           -e MONGO_INITDB_ROOT_PASSWORD=smoke \
           "${{ inputs.mongoImage }}" >/dev/null
 
+        MONGO_READY_ATTEMPTS=$(( ${{ inputs.timeoutSeconds }} / 2 ))
+        if [ "$MONGO_READY_ATTEMPTS" -lt 1 ]; then
+          MONGO_READY_ATTEMPTS=1
+        fi
+
+        for attempt in $(seq 1 "$MONGO_READY_ATTEMPTS"); do
+          if docker exec "$MONGO_NAME" mongosh --quiet \
+              --username smoke \
+              --password smoke \
+              --authenticationDatabase admin \
+              --eval 'db.runCommand({ ping: 1 }).ok' admin >/dev/null 2>&1; then
+            echo "MongoDB is ready."
+            break
+          fi
+
+          if [ "$attempt" -eq "$MONGO_READY_ATTEMPTS" ]; then
+            echo "MongoDB readiness check timed out."
+            docker logs "$MONGO_NAME"
+            exit 1
+          fi
+
+          sleep 2
+        done
+
         docker run -d --name "$APP_NAME" --network "$NETWORK_NAME" \
           -e SERVER_PORT=5000 \
+          -e DB_TIMEOUT=30000 \
           -e DB_ADDRESS="$MONGO_NAME" \
           -e DB_PORT=27017 \
           -e DB_NAME=web-scraper \

--- a/.github/actions/runtime-smoke-check/action.yml
+++ b/.github/actions/runtime-smoke-check/action.yml
@@ -37,6 +37,12 @@ runs:
           -e MONGO_INITDB_ROOT_PASSWORD=smoke \
           "${{ inputs.mongoImage }}" >/dev/null
 
+        if ! docker exec "$MONGO_NAME" sh -c 'command -v mongosh >/dev/null 2>&1'; then
+          echo "MongoDB smoke image does not provide mongosh; cannot run readiness probe."
+          docker logs "$MONGO_NAME"
+          exit 1
+        fi
+
         MONGO_READY_ATTEMPTS=$(( ${{ inputs.timeoutSeconds }} / 2 ))
         if [ "$MONGO_READY_ATTEMPTS" -lt 1 ]; then
           MONGO_READY_ATTEMPTS=1

--- a/.github/actions/runtime-smoke-check/action.yml
+++ b/.github/actions/runtime-smoke-check/action.yml
@@ -4,6 +4,10 @@ inputs:
   imageName:
     description: Docker image to run for smoke validation.
     required: true
+  mongoImage:
+    description: MongoDB image used for runtime smoke validation.
+    required: false
+    default: "mongo:7.0"
   timeoutSeconds:
     description: Max seconds to wait for healthy status.
     required: false
@@ -31,7 +35,7 @@ runs:
         docker run -d --name "$MONGO_NAME" --network "$NETWORK_NAME" \
           -e MONGO_INITDB_ROOT_USERNAME=smoke \
           -e MONGO_INITDB_ROOT_PASSWORD=smoke \
-          mongo >/dev/null
+          "${{ inputs.mongoImage }}" >/dev/null
 
         docker run -d --name "$APP_NAME" --network "$NETWORK_NAME" \
           -e SERVER_PORT=5000 \

--- a/.github/actions/runtime-smoke-check/action.yml
+++ b/.github/actions/runtime-smoke-check/action.yml
@@ -37,11 +37,18 @@ runs:
           -e MONGO_INITDB_ROOT_PASSWORD=smoke \
           "${{ inputs.mongoImage }}" >/dev/null
 
-        if ! docker exec "$MONGO_NAME" sh -c 'command -v mongosh >/dev/null 2>&1'; then
-          echo "MongoDB smoke image does not provide mongosh; cannot run readiness probe."
+        MONGO_SHELL=""
+        if docker exec "$MONGO_NAME" sh -c 'command -v mongosh >/dev/null 2>&1'; then
+          MONGO_SHELL="mongosh"
+        elif docker exec "$MONGO_NAME" sh -c 'command -v mongo >/dev/null 2>&1'; then
+          MONGO_SHELL="mongo"
+        else
+          echo "MongoDB smoke image does not provide mongosh or mongo shell; cannot run readiness probe."
           docker logs "$MONGO_NAME"
           exit 1
         fi
+
+        echo "Using MongoDB shell for readiness probe: $MONGO_SHELL"
 
         MONGO_READY_ATTEMPTS=$(( ${{ inputs.timeoutSeconds }} / 2 ))
         if [ "$MONGO_READY_ATTEMPTS" -lt 1 ]; then
@@ -49,7 +56,7 @@ runs:
         fi
 
         for attempt in $(seq 1 "$MONGO_READY_ATTEMPTS"); do
-          if docker exec "$MONGO_NAME" mongosh --quiet \
+          if docker exec "$MONGO_NAME" "$MONGO_SHELL" --quiet \
               --username smoke \
               --password smoke \
               --authenticationDatabase admin \

--- a/.github/release-bundle-files.txt
+++ b/.github/release-bundle-files.txt
@@ -1,0 +1,14 @@
+# Runtime release bundle allowlist
+# Only listed entries are packaged in the release tarball.
+
+Dockerfile
+docker-compose.yml
+package.json
+package-lock.json
+VERSION
+README.md
+LICENSE
+src
+public
+docs/json
+scripts/healthcheck-status.js

--- a/.github/workflows/cd-web-scraper.yml
+++ b/.github/workflows/cd-web-scraper.yml
@@ -33,6 +33,7 @@ jobs:
         uses: ./.github/actions/runtime-smoke-check
         with:
           imageName: web-scraper:smoke
+          mongoImage: mongo:4.4.29-focal
           timeoutSeconds: 120
 
   build:

--- a/.github/workflows/cd-web-scraper.yml
+++ b/.github/workflows/cd-web-scraper.yml
@@ -27,54 +27,11 @@ jobs:
         run: npm test
       - name: Build Docker image (smoke check)
         run: docker build --tag web-scraper:smoke .
-      - name: Start runtime smoke environment
-        run: |
-          docker network create smoke-net
-          docker run -d --name smoke-mongo --network smoke-net \
-            -e MONGO_INITDB_ROOT_USERNAME=smoke \
-            -e MONGO_INITDB_ROOT_PASSWORD=smoke \
-            mongo
-          docker run -d --name smoke-app --network smoke-net \
-            -e SERVER_PORT=5000 \
-            -e DB_ADDRESS=smoke-mongo \
-            -e DB_PORT=27017 \
-            -e DB_NAME=web-scraper \
-            -e DB_USER=smoke \
-            -e DB_PASSWORD=smoke \
-            -e DEMO_BASE=base@demo.com \
-            -e DEMO_PASS=demo-pass \
-            -e CI_USER=ci@test.local \
-            -e CI_PASS=ci-pass \
-            -e JWT_SECRET=smoke-jwt \
-            -e SESSION_SHA=smoke-session \
-            -e CHALLENGE_PREFIX=smoke \
-            -e CHALLENGE_JOIN=- \
-            -e CHALLENGE_EOL_MINS=10 \
-            -e CHALLENGE_EOL_SEPARATOR=@ \
-            web-scraper:smoke
-      - name: Wait for runtime healthcheck
-        run: |
-          for attempt in {1..60}; do
-            status=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' smoke-app)
-            if [ "$status" = "healthy" ]; then
-              echo "Runtime smoke check passed."
-              exit 0
-            fi
-            if [ "$status" = "unhealthy" ]; then
-              echo "Runtime smoke check failed: container reported unhealthy."
-              docker logs smoke-app
-              exit 1
-            fi
-            sleep 2
-          done
-          echo "Runtime smoke check timed out waiting for healthy status."
-          docker logs smoke-app
-          exit 1
-      - name: Teardown runtime smoke environment
-        if: ${{ always() }}
-        run: |
-          docker rm -f smoke-app smoke-mongo || true
-          docker network rm smoke-net || true
+      - name: Run runtime smoke check
+        uses: ./.github/actions/runtime-smoke-check
+        with:
+          imageName: web-scraper:smoke
+          timeoutSeconds: 120
 
   build:
     name: Publish Release Artifacts

--- a/.github/workflows/cd-web-scraper.yml
+++ b/.github/workflows/cd-web-scraper.yml
@@ -115,6 +115,7 @@ jobs:
         uses: ./.github/actions/create-release-bundle
         with:
           bundleTag: ${{ steps.tag.outputs.normalizedTag }}
+          allowlistFile: .github/release-bundle-files.txt
           retentionDays: 14
       - name: Attach release assets to GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/cd-web-scraper.yml
+++ b/.github/workflows/cd-web-scraper.yml
@@ -25,6 +25,8 @@ jobs:
         run: npm ci
       - name: Run test suite
         run: npm test
+      - name: Sync VERSION for smoke validation
+        run: npm run version:sync
       - name: Build Docker image (smoke check)
         run: docker build --tag web-scraper:smoke .
       - name: Run runtime smoke check

--- a/.github/workflows/cd-web-scraper.yml
+++ b/.github/workflows/cd-web-scraper.yml
@@ -27,6 +27,54 @@ jobs:
         run: npm test
       - name: Build Docker image (smoke check)
         run: docker build --tag web-scraper:smoke .
+      - name: Start runtime smoke environment
+        run: |
+          docker network create smoke-net
+          docker run -d --name smoke-mongo --network smoke-net \
+            -e MONGO_INITDB_ROOT_USERNAME=smoke \
+            -e MONGO_INITDB_ROOT_PASSWORD=smoke \
+            mongo
+          docker run -d --name smoke-app --network smoke-net \
+            -e SERVER_PORT=5000 \
+            -e DB_ADDRESS=smoke-mongo \
+            -e DB_PORT=27017 \
+            -e DB_NAME=web-scraper \
+            -e DB_USER=smoke \
+            -e DB_PASSWORD=smoke \
+            -e DEMO_BASE=base@demo.com \
+            -e DEMO_PASS=demo-pass \
+            -e CI_USER=ci@test.local \
+            -e CI_PASS=ci-pass \
+            -e JWT_SECRET=smoke-jwt \
+            -e SESSION_SHA=smoke-session \
+            -e CHALLENGE_PREFIX=smoke \
+            -e CHALLENGE_JOIN=- \
+            -e CHALLENGE_EOL_MINS=10 \
+            -e CHALLENGE_EOL_SEPARATOR=@ \
+            web-scraper:smoke
+      - name: Wait for runtime healthcheck
+        run: |
+          for attempt in {1..60}; do
+            status=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' smoke-app)
+            if [ "$status" = "healthy" ]; then
+              echo "Runtime smoke check passed."
+              exit 0
+            fi
+            if [ "$status" = "unhealthy" ]; then
+              echo "Runtime smoke check failed: container reported unhealthy."
+              docker logs smoke-app
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "Runtime smoke check timed out waiting for healthy status."
+          docker logs smoke-app
+          exit 1
+      - name: Teardown runtime smoke environment
+        if: ${{ always() }}
+        run: |
+          docker rm -f smoke-app smoke-mongo || true
+          docker network rm smoke-net || true
 
   build:
     name: Publish Release Artifacts

--- a/.github/workflows/cd-web-scraper.yml
+++ b/.github/workflows/cd-web-scraper.yml
@@ -9,8 +9,28 @@ on:
     types: [published]
 
 jobs:
+  validate:
+    name: Validate Release Runtime
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run test suite
+        run: npm test
+      - name: Build Docker image (smoke check)
+        run: docker build --tag web-scraper:smoke .
+
   build:
     name: Publish Release Artifacts
+    needs: validate
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ghcr.io/${{ github.repository }}

--- a/.github/workflows/cd-web-scraper.yml
+++ b/.github/workflows/cd-web-scraper.yml
@@ -72,18 +72,53 @@ jobs:
       - name: Sync VERSION for release artifacts
         run: npm run version:sync
       - name: Build and push image
+        id: image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+      - name: Prepare digest-first image references
+        run: |
+          IMAGE_DIGEST="${{ steps.image.outputs.digest }}"
+          if [ -z "$IMAGE_DIGEST" ]; then
+            echo "Missing image digest output from build step."
+            exit 1
+          fi
+
+          IMMUTABLE_IMAGE_REF="${{ env.IMAGE_NAME }}@${IMAGE_DIGEST}"
+          VERSION_TAG_REF="${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.normalizedTag }}"
+          LATEST_TAG_REF="${{ env.IMAGE_NAME }}:latest"
+
+          {
+            echo "Immutable image reference (recommended for production):"
+            echo "$IMMUTABLE_IMAGE_REF"
+            echo
+            echo "Tag references:"
+            echo "$VERSION_TAG_REF"
+            if [ "${{ github.event.release.prerelease }}" = "false" ]; then
+              echo "$LATEST_TAG_REF"
+            fi
+          } > image-references.txt
+
+          {
+            echo "### Container Image References"
+            echo ""
+            echo "- Recommended (immutable): \`$IMMUTABLE_IMAGE_REF\`"
+            echo "- Version tag: \`$VERSION_TAG_REF\`"
+            if [ "${{ github.event.release.prerelease }}" = "false" ]; then
+              echo "- Convenience tag: \`$LATEST_TAG_REF\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Create release bundle and upload workflow artifact
         id: bundle
         uses: ./.github/actions/create-release-bundle
         with:
           bundleTag: ${{ steps.tag.outputs.normalizedTag }}
           retentionDays: 14
-      - name: Attach archive to GitHub release
+      - name: Attach release assets to GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ steps.bundle.outputs.archiveName }}
+          files: |
+            ${{ steps.bundle.outputs.archiveName }}
+            image-references.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: "web-scraper"
 services:
   mongodb:
     # use mongo:4.4.29-focal when CPU does not support AVX commands
-    image: mongo
+    image: mongo:4.4.29-focal
     container_name: mongodb
     restart: unless-stopped
     env_file: ./.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: "web-scraper"
 
 services:
   mongodb:
-    # use mongo:4.4.29-focal when CPU does not support AVX commands
+    # pin MongoDB to 4.4.29-focal for compatibility, including CPUs without AVX support
     image: mongo:4.4.29-focal
     container_name: mongodb
     restart: unless-stopped


### PR DESCRIPTION
This patch fixes #199 
New build and runtime smoke tests related to Docker publish are in place. I've also added files allowlist for release artifacts (tarball).