### PR TITLE
Added log retention policy to Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ There are two supported ways to run web-scraper service:
   docker logs scraper
   ```
 
-Docker Compose log retention is enabled for both `app` and `mongodb` services:
+Docker log rotation is configured for both `app` and `mongodb` services through `docker-compose.yml`:
 - Logging driver: `json-file`
 - Max single log file size: `10m`
 - Max retained log files: `5`
 
-This keeps container logs from growing without limits. To adjust retention, update `max-size` and `max-file` values in `docker-compose.yml` under `x-logging`.
+These Docker logging driver settings keep container logs from growing without limits. To adjust log rotation, update `max-size` and `max-file` values in `docker-compose.yml` under `x-logging`.
 
 After the service is up and running the next steps are as follows:
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ There are two supported ways to run web-scraper service:
   docker logs scraper
   ```
 
+Docker Compose log retention is enabled for both `app` and `mongodb` services:
+- Logging driver: `json-file`
+- Max single log file size: `10m`
+- Max retained log files: `5`
+
+This keeps container logs from growing without limits. To adjust retention, update `max-size` and `max-file` values in `docker-compose.yml` under `x-logging`.
+
 After the service is up and running the next steps are as follows:
 
 1. Open the web-browser and navigate to the configured `IP:PORT` address.<br>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,11 @@
 name: "web-scraper"
 
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
 services:
   mongodb:
     # pin MongoDB to 4.4.29-focal for compatibility, including CPUs without AVX support
@@ -14,6 +20,7 @@ services:
       - $DB_PORT:$DB_PORT
     volumes:
       - mongodb_data:/data/db
+    logging: *default-logging
   app:
     container_name: scraper
     restart: unless-stopped
@@ -30,6 +37,7 @@ services:
       - $SERVER_PORT:$SERVER_PORT
     depends_on:
       - mongodb
+    logging: *default-logging
 
 volumes:
   mongodb_data:


### PR DESCRIPTION
This patch fixes #204 
Now each container now keeps up to about 50 MB of rotated logs instead of growing indefinitely.